### PR TITLE
Add Woonzeker Rentals parser 

### DIFF
--- a/hestia.py
+++ b/hestia.py
@@ -383,7 +383,7 @@ class HomeResults:
         param_needle = '}('
         param_start = data.find(param_needle)
         param_end = data.find('));', param_start)
-        params = next(csv.reader(data[param_start + len(param_needle):param_end])) # Use csv reader to allow for commas in strings.
+        params = next(csv.reader([data[param_start + len(param_needle):param_end]], skipinitialspace=True)) # Use csv reader to allow for commas in strings.
 
         mapping = {}
         for i in range(0, min(len(func_args), len(params))):
@@ -396,6 +396,9 @@ class HomeResults:
                 return s
         for res in results:
             home = Home(agency="woonzeker")
+
+            if (mapping_or_raw(res['mappedStatus']).lower() == "onder optie"):
+                continue # This house is already gone
 
             address = res['address']
             home.address = f"{mapping_or_raw(address['street'])} {mapping_or_raw(address['houseNumber'])} {mapping_or_raw(address['houseNumberExtension'])}".strip()

--- a/hestia.py
+++ b/hestia.py
@@ -396,11 +396,18 @@ class HomeResults:
                     continue
             home.url = f"https://woonzeker.com/aanbod/{home.city}/{res['slug']}"
             rawprice = res['handover']['formattedPrice']
-            end = rawprice.index(",") # Every price is terminated with a trailing ,
             try:
+                end = rawprice.index(",") # Every price is terminated with a trailing ,
                 home.price = int(rawprice[2:end].strip())
             except ValueError:
-                continue
+                match rawprice:
+                    case 'aT':
+                        home.price = 2500
+                    case 'cN':
+                        home.price = 2050
+                    case _:
+                        logging.warning("Unknown price mapping: {}", rawprice)
+                        continue
             self.homes.append(home)
 
 

--- a/hestia.py
+++ b/hestia.py
@@ -6,6 +6,7 @@ import requests
 import re
 import chompjs
 import csv
+from urllib import parse
 from psycopg2.extras import RealDictCursor
 from bs4 import BeautifulSoup
 from secrets import TOKEN, DB
@@ -403,7 +404,7 @@ class HomeResults:
             address = res['address']
             home.address = f"{mapping_or_raw(address['street'])} {mapping_or_raw(address['houseNumber'])} {mapping_or_raw(address['houseNumberExtension'])}".strip()
             home.city = mapping_or_raw(address['location'])
-            home.url = f"https://woonzeker.com/aanbod/{home.city}/{res['slug']}" # slug contains the proper url formatting and is always filled in
+            home.url = parse.quote(f"https://woonzeker.com/aanbod/{home.city}/{res['slug']}") # slug contains the proper url formatting and is always filled in
             home.price = int(mapping_or_raw(res['handover']['price']))
             self.homes.append(home)
 

--- a/hestia.py
+++ b/hestia.py
@@ -422,7 +422,7 @@ class HomeResults:
             else:
                 home.address = f"{mapping_or_raw(address['street'])} {mapping_or_raw(address['houseNumber'])}".strip()
             home.city = mapping_or_raw(address['location'])
-            home.url = parse.quote(f"https://woonzeker.com/aanbod/{home.city}/{res['slug']}") # slug contains the proper url formatting and is always filled in
+            home.url = "https://woonzeker.com" + parse.quote(f"/aanbod/{home.city}/{res['slug']}") # slug contains the proper url formatting and is always filled in
             home.price = int(mapping_or_raw(res['handover']['price']))
             self.homes.append(home)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ asyncio >= 3.4.3
 beautifulsoup4 >= 4.12.2
 requests >= 2.28.2
 psycopg2-binary >= 2.9.6
+chompjs >= 1.3.0


### PR DESCRIPTION
Woonzeker Rentals is a rental service in Den Haag and Rotterdam. This PR adds a parser for them.

Important to note is that in the UI you can't see the house number, but it is defined in the URL.. I use a regex to get the various parts out of the URL which I have validated using regex101. The regex is as follows:

`/aanbod/([^/]+)/(.*)-([0-9]+)(-[a-zA-Z0-9]+)?`