### PR TITLE
ooms: remove space between house number and addition

### DIFF
--- a/hestia.py
+++ b/hestia.py
@@ -385,7 +385,7 @@ class HomeResults:
             if addition == None:
                 addition = ""
 
-            home.address = f"{res['street_name']} {res['house_number']} {addition}"
+            home.address = f"{res['street_name']} {res['house_number']}{addition}"
             home.city = res["place"]
             home.price = res["rent_price"]
             self.homes.append(home)


### PR DESCRIPTION
This was changed in 9d3f4b076616059486dcc01b2c6721ab1f3236b6 for some reason, and it breaks the equality between Ooms and Funda.

Maybe we want to introduce a canonicalization in the address setter? We could strip the end of the string to avoid this.