### PR TITLE
Add Hexia platform parser

### DIFF
--- a/hestia.py
+++ b/hestia.py
@@ -264,6 +264,7 @@ class HomeResults:
                    'mosaic-plaza': 'https://plaza.newnewnew.space/aanbod/huurwoningen/details/',
                    'oostwestwonen': 'https://woningzoeken.oostwestwonen.nl/aanbod/nu-te-huur/huurwoningen/details/',
                    'noordveluwe': 'https://www.hurennoordveluwe.nl/aanbod/nu-te-huur/huurwoningen/details/',
+                   'woninghuren': 'https://www.woninghuren.nl/aanbod/te-huur/details/',
                    'hollandrijnland': 'https://www.hureninhollandrijnland.nl/aanbod/nu-te-huur/huurwoningen/details/'}
             home.url = f"{map[corp]}{res['urlKey']}"
             

--- a/hestia.py
+++ b/hestia.py
@@ -265,6 +265,7 @@ class HomeResults:
                    'oostwestwonen': 'https://woningzoeken.oostwestwonen.nl/aanbod/nu-te-huur/huurwoningen/details/',
                    'noordveluwe': 'https://www.hurennoordveluwe.nl/aanbod/nu-te-huur/huurwoningen/details/',
                    'woninghuren': 'https://www.woninghuren.nl/aanbod/te-huur/details/',
+                   'woonnethaaglanden': 'https://www.woonnet-haaglanden.nl/aanbod/nu-te-huur/te-huur/details/',
                    'hollandrijnland': 'https://www.hureninhollandrijnland.nl/aanbod/nu-te-huur/huurwoningen/details/'}
             home.url = f"{map[corp]}{res['urlKey']}"
             

--- a/hestia.py
+++ b/hestia.py
@@ -250,23 +250,30 @@ class HomeResults:
             
             # Since the customers of this platform can have different subdomains, paths etc..
             # We have to map the corporation to a full path where the listing is accessible
-            map = {'wooniezie': 'https://www.wooniezie.nl/aanbod/nu-te-huur/te-huur/details/',
-                   'hwwonen': 'https://www.thuisbijhwwonen.nl/aanbod/nu-te-huur/huurwoningen/details/',
-                   'thuisindeachterhoek': 'https://www.thuisindeachterhoek.nl/aanbod/te-huur/details/',
+            map = {'antares': 'https://wonen.thuisbijantares.nl/aanbod/nu-te-huur/te-huur/details/',
                    'dewoningzoeker': 'https://www.dewoningzoeker.nl/aanbod/te-huur/details/',
-                   'thuispoortstudenten': 'https://www.thuispoortstudentenwoningen.nl/aanbod/details/',
-                   'thuispoort': 'https://www.thuispoort.nl/aanbod/te-huur/details/',
-                   'zuidwestwonen': 'https://www.zuidwestwonen.nl/aanbod/nu-te-huur/huurwoningen/details/',
-                   'thuisinlimburg': 'https://www.thuisinlimburg.nl/aanbod/nu-te-huur/huurwoningen/details/',
+                   'frieslandhuurt': 'https://www.frieslandhuurt.nl/aanbod/nu-te-huur/huurwoningen/details/',
+                   'hollandrijnland': 'https://www.hureninhollandrijnland.nl/aanbod/nu-te-huur/huurwoningen/details/',
+                   'hwwonen': 'https://www.thuisbijhwwonen.nl/aanbod/nu-te-huur/huurwoningen/details/',
                    'klikvoorwonen': 'https://www.klikvoorwonen.nl/aanbod/nu-te-huur/huurwoningen/details/',
                    'mercatus-aanbod': 'https://woningaanbod.mercatus.nl/aanbod/te-huur/details/',
-                   'woninginzicht': 'https://www.woninginzicht.nl/aanbod/te-huur/details/',
                    'mosaic-plaza': 'https://plaza.newnewnew.space/aanbod/huurwoningen/details/',
-                   'oostwestwonen': 'https://woningzoeken.oostwestwonen.nl/aanbod/nu-te-huur/huurwoningen/details/',
                    'noordveluwe': 'https://www.hurennoordveluwe.nl/aanbod/nu-te-huur/huurwoningen/details/',
+                   'oostwestwonen': 'https://woningzoeken.oostwestwonen.nl/aanbod/nu-te-huur/huurwoningen/details/',
+                   'studentenenschede': 'https://www.roomspot.nl/aanbod/te-huur/details/',
+                   'svnk': 'https://www.svnk.nl/aanbod/nu-te-huur/huurwoningen/details/',
+                   'thuisindeachterhoek': 'https://www.thuisindeachterhoek.nl/aanbod/te-huur/details/',
+                   'thuisinlimburg': 'https://www.thuisinlimburg.nl/aanbod/nu-te-huur/huurwoningen/details/',
+                   'thuiskompas': 'https://www.thuiskompas.nl/aanbod/nu-te-huur/te-huur/details/',
+                   'thuispoort': 'https://www.thuispoort.nl/aanbod/te-huur/details/',
+                   'thuispoortstudenten': 'https://www.thuispoortstudentenwoningen.nl/aanbod/details/',
                    'woninghuren': 'https://www.woninghuren.nl/aanbod/te-huur/details/',
+                   'woninginzicht': 'https://www.woninginzicht.nl/aanbod/te-huur/details/',
+                   'wooniezie': 'https://www.wooniezie.nl/aanbod/nu-te-huur/te-huur/details/',
+                   'woonkeusstedendriehoek': 'https://www.woonkeus-stedendriehoek.nl/aanbod/nu-te-huur/huurwoningen/details/',
                    'woonnethaaglanden': 'https://www.woonnet-haaglanden.nl/aanbod/nu-te-huur/te-huur/details/',
-                   'hollandrijnland': 'https://www.hureninhollandrijnland.nl/aanbod/nu-te-huur/huurwoningen/details/'}
+                   'woontij': 'https://www.wonenindekop.nl/aanbod/nu-te-huur/huurwoningen/details/',
+                   'zuidwestwonen': 'https://www.zuidwestwonen.nl/aanbod/nu-te-huur/huurwoningen/details/'}
             home.url = f"{map[corp]}{res['urlKey']}"
             
             self.homes.append(home)


### PR DESCRIPTION
As mentioned in #53. Wooniezie and many other websites just buy the platform from a common third party.

Endpoint to get the data, no data needs to be posted:
`https://{corp}api.hexia.io/api/v1/actueel-aanbod?limit=99&sort=-publicationDate`

Where `corp` is the slug of the corporation which you want to parse. You can get this by simply filtering the request path in inspect element in your browser. The name is always appended with `api` and is sent to hexia.io, though sometimes it's also zig365.nl, but using hexia.io seems to work anyway, so no special handling is needed. Current supported targets:

- wooniezie
- hwwonen
- thuisindeachterhoek
- dewoningzoeker
- thuispoortstudenten
- thuispoort
- zuidwestwonen
- thuisinlimburg
- klikvoorwonen
- mercatus-aanbod
- woninginzicht
- mosaic-plaza
- oostwestwonen
- noordveluwe
- woninghuren
- woonnethaaglanden
- hollandrijnland
- antares
- studentenenschede
- thuiskompas
- woonkeusstedendriehoek
- woontij
- frieslandhuurt
- svnk

To generate a direct link to the listing we need to map the corp to the full website path of the corporation which is different and not reported in the API. So for this I created a dictionary with mappings from the corp slug to the full listing URL, you can get this by simply opening a random listing in your browser.

To install this in the system it's the same as with the DAK endpoints, but instead of regions it's the corporate slugs.