### PR TITLE
Add Beumer Makelaars scraper

### DIFF
--- a/docker/docker-compose-dev.yml
+++ b/docker/docker-compose-dev.yml
@@ -55,6 +55,12 @@ services:
     environment:
       - HESTIA_TARGET=atta
 
+  hestia-scraper-beumer-dev:
+    <<: *scraper-dev-base
+    container_name: hestia-scraper-beumer-dev
+    environment:
+      - HESTIA_TARGET=beumer
+
   hestia-scraper-easylease-dev:
     <<: *scraper-dev-base
     container_name: hestia-scraper-easylease-dev

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -55,6 +55,12 @@ services:
     environment:
       - HESTIA_TARGET=atta
 
+  hestia-scraper-beumer:
+    <<: *scraper-base
+    container_name: hestia-scraper-beumer
+    environment:
+      - HESTIA_TARGET=beumer
+
   hestia-scraper-easylease:
     <<: *scraper-base
     container_name: hestia-scraper-easylease

--- a/hestia/hestia_utils/parser.py
+++ b/hestia/hestia_utils/parser.py
@@ -143,6 +143,8 @@ class HomeResults:
             self.parse_hoekstra(raw)
         elif source == "easylease":
             self.parse_easylease(raw)
+        elif source == "beumer":
+            self.parse_beumer(raw)
         else:
             raise ValueError(f"Unknown source: {source}")
 
@@ -993,6 +995,45 @@ class HomeResults:
                 home.price = int(res["data"]["price"])
                 home.sqm = int(res["data"]["surface"])
                 self.homes.append(home)
+
+    def parse_beumer(self, r: requests.models.Response):
+        soup = BeautifulSoup(r.content, "html.parser")
+        results = soup.select("a.card-house")
+        for res in results:
+            label_tag = res.select_one(".card-house__label")
+            if not label_tag or label_tag.get_text(strip=True).lower() != "te huur":
+                continue
+            address_tag = res.select_one(".card-house__content h3")
+            info_tag = res.select_one(".card-house__content > p")
+            if not address_tag or not info_tag:
+                continue
+            address = " ".join(address_tag.get_text(" ", strip=True).split())
+            if not re.search(r"\d", address):
+                continue
+            info_text = info_tag.get_text(" ", strip=True)
+            # Format: "Utrecht • € 1.775 ,- p/m"
+            parts = info_text.split("•")
+            if len(parts) < 2:
+                continue
+            city = parts[0].strip()
+            price_digits = ''.join(ch for ch in parts[1] if ch.isdigit())
+            if not city or not price_digits:
+                continue
+            home = Home(agency="beumer")
+            home.address = address
+            home.city = city
+            home.url = str(res["href"])
+            home.price = int(price_digits)
+            sqm_tag = res.select_one(".card-house__content__data .icon-house")
+            if sqm_tag:
+                container = sqm_tag.find_parent("p")
+                if container:
+                    m = re.search(r"(\d{1,4})\s*m", container.get_text(" ", strip=True))
+                    if m:
+                        sqm_i = int(m.group(1))
+                        if 0 < sqm_i < 2000:
+                            home.sqm = sqm_i
+            self.homes.append(home)
 
     def parse_maxxhuren(self, r: requests.models.Response):
         soup = BeautifulSoup(r.content, "html.parser")

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1461,6 +1461,69 @@ class TestParseIkwilhuren:
         assert len(results.homes) == 0
 
 
+class TestParseBeumer:
+    def test_basic_parsing(self, mock_response):
+        html = """
+        <a href="https://www.beumer.nl/wonen/object/erroll-garnerstraat-113-utrecht/" class="card-house">
+            <div class="offer">
+                <div class="card-house__thumb">
+                    <div class="card-house__label__holder">
+                        <div class="card-house__label">Te huur</div>
+                    </div>
+                </div>
+                <div class="card-house__content">
+                    <h3>Erroll Garnerstraat 113</h3>
+                    <p>Utrecht &bull; &euro; 1.775 ,- p/m</p>
+                    <div class="card-house__content__data">
+                        <p><i class="icon icon-house"></i><span>68 m<sup>2</sup></span></p>
+                    </div>
+                </div>
+            </div>
+        </a>
+        """
+        r = mock_response(html)
+        results = HomeResults("beumer", r)
+        assert len(results.homes) == 1
+        assert results[0].agency == "beumer"
+        assert results[0].address == "Erroll Garnerstraat 113"
+        assert results[0].city == "Utrecht"
+        assert results[0].price == 1775
+        assert results[0].sqm == 68
+        assert results[0].url == "https://www.beumer.nl/wonen/object/erroll-garnerstraat-113-utrecht/"
+
+    def test_filters_verhuurd(self, mock_response):
+        html = """
+        <a href="https://www.beumer.nl/wonen/object/x/" class="card-house">
+            <div class="offer">
+                <div class="card-house__label">Verhuurd</div>
+                <div class="card-house__content">
+                    <h3>Grifthoek 114</h3>
+                    <p>Utrecht &bull; &euro; 1.995 ,- p/m</p>
+                </div>
+            </div>
+        </a>
+        """
+        r = mock_response(html)
+        results = HomeResults("beumer", r)
+        assert len(results.homes) == 0
+
+    def test_filters_address_without_house_number(self, mock_response):
+        html = """
+        <a href="https://www.beumer.nl/wonen/object/x/" class="card-house">
+            <div class="offer">
+                <div class="card-house__label">Te huur</div>
+                <div class="card-house__content">
+                    <h3>Nieuwbouwproject</h3>
+                    <p>Utrecht &bull; &euro; 1.500 ,- p/m</p>
+                </div>
+            </div>
+        </a>
+        """
+        r = mock_response(html)
+        results = HomeResults("beumer", r)
+        assert len(results.homes) == 0
+
+
 class TestParseMaxxhuren:
     def test_basic_parsing(self, mock_response):
         html = """


### PR DESCRIPTION
## Summary
- New HTML parser for beumer.nl/huurwoningen (no public API; scrapes `a.card-house` cards)
- Filters out `Verhuurd` listings and addresses without a house number
- Per-agency container entries added for dev + prod compose files

## Test plan
- [x] `pytest tests/test_parsers.py -k Beumer` — 3 cases pass
- [x] Live run via `hestia-scraper-beumer-dev` persists 4 active listings; 5 verhuurd filtered
- [x] Sample listing URLs return HTTP 200
- [x] All parsed addresses contain a house number