### PR TITLE
Allow host-network scrapers with IPv6 rotation and custom cron schedule

### DIFF
--- a/docker/Dockerfile.scraper
+++ b/docker/Dockerfile.scraper
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 FROM python:3.11-slim-bookworm
-RUN apt-get update && apt-get install cron procps gcc -y && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install cron procps gcc iproute2 -y && rm -rf /var/lib/apt/lists/*
 
 COPY hestia/requirements.txt /scraper/requirements.txt
 RUN pip3 install -r /scraper/requirements.txt

--- a/docker/Dockerfile.scraper
+++ b/docker/Dockerfile.scraper
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 FROM python:3.11-slim-bookworm
-RUN apt-get update && apt-get install cron procps gcc iproute2 -y && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install cron procps gcc iproute2 tzdata -y && rm -rf /var/lib/apt/lists/*
 
 COPY hestia/requirements.txt /scraper/requirements.txt
 RUN pip3 install -r /scraper/requirements.txt

--- a/docker/docker-compose-dev.yml
+++ b/docker/docker-compose-dev.yml
@@ -193,7 +193,7 @@ services:
       - HESTIA_TARGET=ikwilhuren
       - HESTIA_DB_HOST=127.0.0.1
       - HESTIA_DB_PORT=54321
-      - HESTIA_CRON_SCHEDULE=*/5 7-22 * * *
+      - HESTIA_CRON_SCHEDULE=*/5 6-22 * * *
       - TZ=Europe/Amsterdam
 
   hestia-scraper-krk-dev:

--- a/docker/docker-compose-dev.yml
+++ b/docker/docker-compose-dev.yml
@@ -176,10 +176,24 @@ services:
       - HESTIA_TARGET=hoekstra
 
   hestia-scraper-ikwilhuren-dev:
-    <<: *scraper-dev-base
     container_name: hestia-scraper-ikwilhuren-dev
+    healthcheck:
+      test: pgrep cron || exit 1
+      start_period: 5s
+    image: wtfloris/hestia-scraper:dev
+    init: true
+    network_mode: host
+    cap_add:
+      - NET_ADMIN
+    restart: unless-stopped
+    volumes:
+      - /home/robot/hestia/data:/data
+    working_dir: /scraper
     environment:
       - HESTIA_TARGET=ikwilhuren
+      - HESTIA_DB_HOST=127.0.0.1
+      - HESTIA_DB_PORT=54321
+      - HESTIA_CRON_SCHEDULE=*/5 7-22 * * *
 
   hestia-scraper-krk-dev:
     <<: *scraper-dev-base

--- a/docker/docker-compose-dev.yml
+++ b/docker/docker-compose-dev.yml
@@ -194,6 +194,7 @@ services:
       - HESTIA_DB_HOST=127.0.0.1
       - HESTIA_DB_PORT=54321
       - HESTIA_CRON_SCHEDULE=*/5 7-22 * * *
+      - TZ=Europe/Amsterdam
 
   hestia-scraper-krk-dev:
     <<: *scraper-dev-base

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -193,7 +193,7 @@ services:
       - HESTIA_TARGET=ikwilhuren
       - HESTIA_DB_HOST=127.0.0.1
       - HESTIA_DB_PORT=5432
-      - HESTIA_CRON_SCHEDULE=*/5 7-22 * * *
+      - HESTIA_CRON_SCHEDULE=*/5 6-22 * * *
       - TZ=Europe/Amsterdam
 
   hestia-scraper-krk:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -194,6 +194,7 @@ services:
       - HESTIA_DB_HOST=127.0.0.1
       - HESTIA_DB_PORT=5432
       - HESTIA_CRON_SCHEDULE=*/5 7-22 * * *
+      - TZ=Europe/Amsterdam
 
   hestia-scraper-krk:
     <<: *scraper-base

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -176,10 +176,24 @@ services:
       - HESTIA_TARGET=hoekstra
 
   hestia-scraper-ikwilhuren:
-    <<: *scraper-base
     container_name: hestia-scraper-ikwilhuren
+    healthcheck:
+      test: pgrep cron || exit 1
+      start_period: 5s
+    image: wtfloris/hestia-scraper:latest
+    init: true
+    network_mode: host
+    cap_add:
+      - NET_ADMIN
+    restart: unless-stopped
+    volumes:
+      - /root/hestia/data:/data
+    working_dir: /scraper
     environment:
       - HESTIA_TARGET=ikwilhuren
+      - HESTIA_DB_HOST=127.0.0.1
+      - HESTIA_DB_PORT=5432
+      - HESTIA_CRON_SCHEDULE=*/5 7-22 * * *
 
   hestia-scraper-krk:
     <<: *scraper-base

--- a/docker/entrypoint-scraper.sh
+++ b/docker/entrypoint-scraper.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 DELAY=$(shuf -i 0-300 -n 1)
-echo "[$(date -u '+%Y-%m-%d %H:%M:%S UTC')] agency=${HESTIA_TARGET:-maintenance} delay=${DELAY}s"
+SCHEDULE="${HESTIA_CRON_SCHEDULE:-*/5 * * * *}"
+echo "[$(date -u '+%Y-%m-%d %H:%M:%S UTC')] agency=${HESTIA_TARGET:-maintenance} delay=${DELAY}s schedule='${SCHEDULE}'"
 printenv | sed 's/=\(.*\)/="\1"/' > /etc/environment
-echo "*/5 * * * * root . /etc/environment; sleep $DELAY && /usr/local/bin/python3 /scraper/hestia/scraper.py > /proc/1/fd/1 2>/proc/1/fd/2" >> /etc/crontab
+echo "${SCHEDULE} root . /etc/environment; sleep $DELAY && /usr/local/bin/python3 /scraper/hestia/scraper.py > /proc/1/fd/1 2>/proc/1/fd/2" >> /etc/crontab
 exec cron -f

--- a/hestia/hestia_utils/db.py
+++ b/hestia/hestia_utils/db.py
@@ -1,3 +1,4 @@
+import os
 import psycopg2
 import logging
 import json
@@ -7,6 +8,13 @@ from datetime import datetime
 from psycopg2.extras import RealDictCursor, RealDictRow
 
 from hestia_utils.secrets import DB
+
+# Allow per-container overrides for host-network scrapers that can't
+# resolve the docker-internal database hostname.
+if os.environ.get("HESTIA_DB_HOST"):
+    DB["host"] = os.environ["HESTIA_DB_HOST"]
+if os.environ.get("HESTIA_DB_PORT"):
+    DB["port"] = os.environ["HESTIA_DB_PORT"]
 
 logging.basicConfig(
     format="%(asctime)s [%(levelname)s] [%(name)s]: %(message)s",


### PR DESCRIPTION
## Summary
Plumbing so certain scraper containers can run with `network_mode: host` and bind to NET_ADMIN-managed source addresses.

- `Dockerfile.scraper`: install `iproute2`.
- `db.py`: honour `HESTIA_DB_HOST` / `HESTIA_DB_PORT` env vars so host-network containers can reach Postgres on `127.0.0.1` (Docker DNS doesn't resolve in host mode).
- `entrypoint-scraper.sh`: support per-container `HESTIA_CRON_SCHEDULE` override (default unchanged).
- Compose: ikwilhuren service moves to `network_mode: host` + `cap_add: [NET_ADMIN]` with its own DB env + cron schedule.

## Test plan
- [x] Dev stack builds; ikwilhuren container comes up healthy
- [x] DB connectivity works via env-overridden host/port
- [x] Live scrape against the target succeeds and persists new rows
- [x] No host-side side effects remain after a run