### PR TITLE
Run pararius scraper every 10 minutes

### DIFF
--- a/docker/docker-compose-dev.yml
+++ b/docker/docker-compose-dev.yml
@@ -225,6 +225,7 @@ services:
     container_name: hestia-scraper-pararius-dev
     environment:
       - HESTIA_TARGET=pararius
+      - HESTIA_CRON_SCHEDULE=*/10 * * * *
 
   hestia-scraper-rebo-dev:
     <<: *scraper-dev-base

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -225,6 +225,7 @@ services:
     container_name: hestia-scraper-pararius
     environment:
       - HESTIA_TARGET=pararius
+      - HESTIA_CRON_SCHEDULE=*/10 * * * *
 
   hestia-scraper-rebo:
     <<: *scraper-base


### PR DESCRIPTION
Reduce pararius scrape cadence from 5 to 10 minutes via the existing HESTIA_CRON_SCHEDULE override on both dev and prod compose.