### PR TITLE
Add NederWoon scraper

### DIFF
--- a/docker/docker-compose-dev.yml
+++ b/docker/docker-compose-dev.yml
@@ -208,6 +208,12 @@ services:
     environment:
       - HESTIA_TARGET=maxxhuren
 
+  hestia-scraper-nederwoon-dev:
+    <<: *scraper-dev-base
+    container_name: hestia-scraper-nederwoon-dev
+    environment:
+      - HESTIA_TARGET=nederwoon
+
   hestia-scraper-nmg-dev:
     <<: *scraper-dev-base
     container_name: hestia-scraper-nmg-dev

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -208,6 +208,12 @@ services:
     environment:
       - HESTIA_TARGET=maxxhuren
 
+  hestia-scraper-nederwoon:
+    <<: *scraper-base
+    container_name: hestia-scraper-nederwoon
+    environment:
+      - HESTIA_TARGET=nederwoon
+
   hestia-scraper-nmg:
     <<: *scraper-base
     container_name: hestia-scraper-nmg

--- a/hestia/hestia_utils/parser.py
+++ b/hestia/hestia_utils/parser.py
@@ -145,6 +145,8 @@ class HomeResults:
             self.parse_easylease(raw)
         elif source == "beumer":
             self.parse_beumer(raw)
+        elif source == "nederwoon":
+            self.parse_nederwoon(raw)
         else:
             raise ValueError(f"Unknown source: {source}")
 
@@ -1033,6 +1035,49 @@ class HomeResults:
                         sqm_i = int(m.group(1))
                         if 0 < sqm_i < 2000:
                             home.sqm = sqm_i
+            self.homes.append(home)
+
+    def parse_nederwoon(self, r: requests.models.Response):
+        results = BeautifulSoup(r.content, "html.parser").select(".location")
+        for res in results:
+            link_tag = res.select_one("a.see-page-button[href]")
+            price_tag = res.select_one(".heading-md.color-primary")
+            city_tag = res.select_one(".color-medium.fixed-lh")
+            if not link_tag or not price_tag or not city_tag:
+                continue
+
+            price_digits = ''.join(ch for ch in price_tag.get_text(" ", strip=True).split(",")[0] if ch.isdigit())
+            if not price_digits:
+                continue
+            home = Home(agency="nederwoon")
+            home.price = int(price_digits)
+
+            address = link_tag.get_text(" ", strip=True)
+            if not address:
+                continue
+            # Nederwoon usually has no house number — fall back to price like pararius does.
+            if not re.search(r"\d", address):
+                address += f" [€{home.price}]"
+            home.address = address
+
+            city_text = city_tag.get_text(" ", strip=True)
+            home.city = re.sub(r"^\d{4}\s?[A-Za-z]{2}\s+", "", city_text).strip()
+            if not home.city:
+                continue
+
+            href = str(link_tag["href"])
+            home.url = href if href.startswith("http") else "https://www.nederwoon.nl" + href
+
+            for li in res.select("ul li"):
+                txt = li.get_text(" ", strip=True)
+                if "Woonoppervlakte" in txt or "m²" in txt:
+                    m = re.search(r"(\d{1,4})\s*m", txt)
+                    if m:
+                        sqm_i = int(m.group(1))
+                        if 0 < sqm_i < 2000:
+                            home.sqm = sqm_i
+                    break
+
             self.homes.append(home)
 
     def parse_maxxhuren(self, r: requests.models.Response):

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1524,6 +1524,52 @@ class TestParseBeumer:
         assert len(results.homes) == 0
 
 
+class TestParseNederwoon:
+    def test_basic_parsing_appends_price_when_no_house_number(self, mock_response):
+        html = """
+        <div class="location" data-marker-id="38288">
+            <div class="col-lg-4 col-md-3 click-see-page-button">
+                <h2 class="heading-sm">
+                    <a class="see-page-button" href="/huurwoning/den-haag/38288/appartement-leyweg">Leyweg</a>
+                </h2>
+                <p class="color-medium fixed-lh">2545CG Den Haag</p>
+                <p class="color-primary fixed-lh">Appartement</p>
+                <ul>
+                    <li>Woonoppervlakte 95 m²</li>
+                    <li>3 kamers</li>
+                </ul>
+            </div>
+            <div class="col-lg-4 col-md-3 vertical-items start-items click-see-page-button">
+                <p class="heading-md text-regular color-primary">&euro; 1.850,00</p>
+            </div>
+        </div>
+        """
+        r = mock_response(html)
+        results = HomeResults("nederwoon", r)
+        assert len(results.homes) == 1
+        assert results[0].agency == "nederwoon"
+        assert results[0].address == "Leyweg [€1850]"
+        assert results[0].city == "Den Haag"
+        assert results[0].price == 1850
+        assert results[0].sqm == 95
+        assert results[0].url == "https://www.nederwoon.nl/huurwoning/den-haag/38288/appartement-leyweg"
+
+    def test_keeps_house_number_when_present(self, mock_response):
+        html = """
+        <div class="location">
+            <a class="see-page-button" href="/huurwoning/x/1/y">Hoofdstraat 12</a>
+            <p class="color-medium fixed-lh">1011AA Amsterdam</p>
+            <p class="heading-md text-regular color-primary">&euro; 1.200,00</p>
+        </div>
+        """
+        r = mock_response(html)
+        results = HomeResults("nederwoon", r)
+        assert len(results.homes) == 1
+        assert results[0].address == "Hoofdstraat 12"
+        assert results[0].city == "Amsterdam"
+        assert results[0].price == 1200
+
+
 class TestParseMaxxhuren:
     def test_basic_parsing(self, mock_response):
         html = """


### PR DESCRIPTION
## Summary
- New HTML parser for nederwoon.nl (no public API; scrapes `.location` cards from `?city=Nederland`)
- Listings don't expose house numbers, so the address fallback follows pararius's pattern: append \`[€<price>]\` to keep most rows unique. Project listings with identical prices will still collide — same trade-off as pararius.
- Per-agency container entries added for dev + prod compose files

## Test plan
- [x] \`pytest tests/test_parsers.py -k Nederwoon\` — 2 cases pass
- [x] Live run via \`hestia-scraper-nederwoon-dev\` persisted 83 listings
- [x] Sample listing URLs return HTTP 200