### PR TITLE
Public landing page in front of the login gate

### DIFF
--- a/web/hestia_web/app.py
+++ b/web/hestia_web/app.py
@@ -679,11 +679,21 @@ def add_security_headers(response):
 
 @app.route("/")
 def index():
-    """Landing page with email input form."""
+    """Public landing page (shopfront). Logged-in users go straight to the tool.
+
+    The hero contains the email signup form, which remains the only entry point
+    into the gated dashboard — the landing layer sits in front of that gate.
+    """
     if get_current_email() is not None:
         return redirect(url_for("dashboard"))
     message = request.args.get("message")
-    return render_template("index.html", title="Login", message=message, contact_only=True)
+    return render_template(
+        "landing.html",
+        title="Free rental-home alerts for the Netherlands",
+        message=message,
+        landing=True,
+        base_url=app.config["BASE_URL"],
+    )
 
 
 @app.route("/login", methods=["POST"])
@@ -1881,9 +1891,12 @@ def avatar():
 
 @app.route("/api/statistics")
 @limiter.limit("30 per minute")
-@api_client_auth_required
 def api_statistics():
-    """Return public statistics about homes and subscribers."""
+    """Return public statistics about homes and subscribers.
+
+    Public (no auth) so the landing page can show aggregate trust numbers.
+    Only exposes non-sensitive counts, never any per-user data.
+    """
     try:
         with get_db() as conn:
             with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
@@ -1931,9 +1944,13 @@ def api_statistics():
 
 
 @app.route("/api/donation-link")
-@api_client_auth_required
+@limiter.limit("30 per minute")
 def donation_link():
-    """Return the donation link from the database."""
+    """Return the donation link from the database.
+
+    Public (no auth) so the landing page footer can link to the donation page.
+    Only returns a single public donation URL.
+    """
     try:
         with get_db() as conn:
             with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:

--- a/web/static/base.js
+++ b/web/static/base.js
@@ -19,6 +19,14 @@
     var resolved = stored || (preferred.toLowerCase().startsWith('nl') ? 'nl' : 'en');
     document.documentElement.setAttribute('lang', resolved);
 })();
+(function() {
+    // Hide iOS-app links on Android (the app is iOS-only). Runs in <head>
+    // before render so the link never flashes. Fails open if detection misses.
+    var ua = navigator.userAgent || '';
+    var isAndroid = /Android/i.test(ua) ||
+        (navigator.userAgentData && navigator.userAgentData.platform === 'Android');
+    if (isAndroid) document.documentElement.classList.add('is-android');
+})();
 
 function toggleTheme() {
     var current = document.documentElement.getAttribute('data-theme');
@@ -139,7 +147,38 @@ var HESTIA_I18N = {
         'browser_notif_new_one': '1 new home has been found',
         'browser_notif_new_many': '{count} new homes have been found',
         'browser_notif_ios_info': 'Browser notifications are not available due to iOS restrictions. Download the <a href="https://apps.apple.com/app/id6760269825" target="_blank" rel="noopener noreferrer">Hestia app for iPhone</a> to get notifications on your phone!',
-        'experimental_warning': 'Hestia is still a work in progress \u2014 you may experience some instability here and there!'
+        'experimental_warning': 'Hestia is still a work in progress \u2014 you may experience some instability here and there!',
+        'landing_login': 'Log in',
+        'landing_login_title': 'Log in or sign up',
+        'landing_login_desc': "Enter your email and we'll send you a login link. No password needed.",
+        'landing_hero_title': 'Find your next rental home, <span class="landing-hl">for free</span>',
+        'landing_hero_sub': 'Hestia watches Dutch rental sites for you and sends a notification within minutes of a new listing that matches your filters. Be the first to respond!',
+        'landing_cta_note': 'Enter your email to get started. We only use it to save your preferences.',
+        'landing_ios': 'Or get the iOS app',
+        'landing_how_title': 'How it works',
+        'landing_step1_title': 'Set your filters',
+        'landing_step1_text': 'Choose your cities, price range and minimum size. Adjust them anytime.',
+        'landing_step2_title': 'Get notified in minutes',
+        'landing_step2_text': 'The moment a matching home appears on any monitored site, Hestia lets you know.',
+        'landing_step3_title': 'Be first to respond',
+        'landing_step3_text': 'In a tight market, minutes matter. Reach out before the crowd does.',
+        'landing_demo_title': 'A preview of your feed',
+        'landing_demo_sub': 'Set your filters and real matches appear within minutes of going online.',
+        'landing_demo_time1': '1 minute ago',
+        'landing_demo_time2': '6 minutes ago',
+        'landing_demo_time3': '7 minutes ago',
+        'landing_coverage_title': 'Broad, deduplicated coverage',
+        'landing_coverage_text': 'Hestia continuously monitors a wide range of major Dutch rental platforms and housing agencies, and removes duplicate listings across sources, so you see each home only once.',
+        'landing_story_title': 'Why Hestia exists',
+        'landing_story_text': "I built Hestia for myself while looking for a place after my studies: I'm lazy and like to automate as much as I can. Once I'd found something I forwarded it to a few friends, who forwarded it to theirs, and on it went until today: by now I've helped thousands of people find a home!",
+        'landing_faq_title': 'Frequently Asked Questions',
+        'landing_final_title': 'Ready to find your new home?',
+        'landing_final_sub': "Did I mention it's free? Enter your email and find your new home!",
+        'landing_final_btn': 'Get started',
+        'landing_footer_contact': 'Contact',
+        'landing_footer_privacy': 'Privacy & cookies',
+        'landing_footer_source': 'GitHub',
+        'landing_footer_ios': 'iOS app'
     },
     nl: {
         'welcome_title': 'Welkom bij Hestia',
@@ -234,7 +273,38 @@ var HESTIA_I18N = {
         'browser_notif_new_one': '1 nieuwe woning gevonden',
         'browser_notif_new_many': '{count} nieuwe woningen gevonden',
         'browser_notif_ios_info': 'Notificaties in de browser werken niet door beperkingen binnen iOS. Download de <a href="https://apps.apple.com/app/id6760269825" target="_blank" rel="noopener noreferrer">Hestia-app voor iPhone</a> om notificaties op je telefoon te ontvangen!',
-        'experimental_warning': 'Hestia is nog volop in ontwikkeling \u2014 het kan zijn dat er soms iets stuk gaat!'
+        'experimental_warning': 'Hestia is nog volop in ontwikkeling \u2014 het kan zijn dat er soms iets stuk gaat!',
+        'landing_login': 'Inloggen',
+        'landing_login_title': 'Inloggen of aanmelden',
+        'landing_login_desc': 'Vul je e-mailadres in, dan sturen we je een inloglink. Geen wachtwoord nodig.',
+        'landing_hero_title': 'Vind je volgende huurwoning, <span class="landing-hl">gratis</span>',
+        'landing_hero_sub': 'Hestia speurt Nederlandse huursites voor je af en stuurt je binnen een paar minuten een melding als er een nieuwe woning opduikt die bij je filters past. Zo ben jij er als eerste bij!',
+        'landing_cta_note': 'Vul je e-mailadres in om te beginnen. We gebruiken ’m alleen om je voorkeuren te bewaren.',
+        'landing_ios': 'Of download de iOS-app',
+        'landing_how_title': 'Hoe het werkt',
+        'landing_step1_title': 'Stel je filters in',
+        'landing_step1_text': 'Kies je steden, prijsklasse en minimale oppervlakte. Aanpassen kan altijd.',
+        'landing_step2_title': 'Binnen minuten een melding',
+        'landing_step2_text': 'Zodra er op een van de sites een woning verschijnt die past, krijg je meteen bericht van Hestia.',
+        'landing_step3_title': 'Wees als eerste',
+        'landing_step3_text': 'Op een krappe woningmarkt telt elke minuut. Reageer voordat de rest het doorheeft.',
+        'landing_demo_title': 'Een voorproefje van je overzicht',
+        'landing_demo_sub': 'Stel je filters in en echte matches verschijnen binnen enkele minuten nadat ze online staan.',
+        'landing_demo_time1': '1 minuut geleden',
+        'landing_demo_time2': '6 minuten geleden',
+        'landing_demo_time3': '7 minuten geleden',
+        'landing_coverage_title': 'Breed bereik, zonder dubbele woningen',
+        'landing_coverage_text': 'Hestia houdt de hele dag talloze websites van grote Nederlandse huurplatforms en woningcorporaties in de gaten, en haalt dezelfde woning bij verschillende bronnen eruit, zodat je elke woning maar \u00e9\u00e9n keer voorbij ziet komen.',
+        'landing_story_title': 'Waarom Hestia bestaat',
+        'landing_story_text': 'Ik bouwde Hestia voor mezelf toen ik na mijn studie op zoek was naar een woning: ik ben namelijk lui en wil graag zoveel mogelijk automatiseren. Toen ik eenmaal iets had gevonden heb ik het naar vrienden doorgestuurd, en die weer naar hun vrienden, en zo door tot vandaag: inmiddels heb ik duizenden mensen aan een huis kunnen helpen!',
+        'landing_faq_title': 'Veelgestelde vragen',
+        'landing_final_title': 'Klaar om je nieuwe woning te vinden?',
+        'landing_final_sub': 'Had ik al gezegd dat het gratis was? Vul je e-mailadres in en vind je nieuwe woning!',
+        'landing_final_btn': 'Aan de slag',
+        'landing_footer_contact': 'Contact',
+        'landing_footer_privacy': 'Privacy & cookies',
+        'landing_footer_source': 'GitHub',
+        'landing_footer_ios': 'iOS-app'
     }
 };
 function hestiaGetLang() {
@@ -322,35 +392,36 @@ var statsModal = null;
 var donateLink = null;
 var statsContent = null;
 
-/* ---- Login form submit guard ---- */
+/* ---- Login form submit guard (covers every /login form on the page) ---- */
 (function() {
-    var loginForm = document.querySelector('form[action="/login"]');
-    if (!loginForm) return;
-    var submitBtn = loginForm.querySelector('.btn-arrow');
-    if (!submitBtn) return;
-    function lockSubmit() {
-        if (loginForm.dataset.submitting === 'true') return false;
-        loginForm.dataset.submitting = 'true';
-        submitBtn.disabled = true;
-        submitBtn.classList.add('is-loading');
-        submitBtn.setAttribute('aria-busy', 'true');
-        var emailInput = loginForm.querySelector('input[type="email"]');
-        if (emailInput) emailInput.disabled = true;
-        return true;
-    }
-
-    submitBtn.addEventListener('click', function(e) {
-        if (!lockSubmit()) {
-            e.preventDefault();
-            e.stopPropagation();
+    var loginForms = document.querySelectorAll('form[action="/login"]');
+    loginForms.forEach(function(loginForm) {
+        var submitBtn = loginForm.querySelector('.btn-arrow');
+        if (!submitBtn) return;
+        function lockSubmit() {
+            if (loginForm.dataset.submitting === 'true') return false;
+            loginForm.dataset.submitting = 'true';
+            submitBtn.disabled = true;
+            submitBtn.classList.add('is-loading');
+            submitBtn.setAttribute('aria-busy', 'true');
+            var emailInput = loginForm.querySelector('input[type="email"]');
+            if (emailInput) emailInput.disabled = true;
+            return true;
         }
-    });
 
-    loginForm.addEventListener('submit', function(e) {
-        if (!lockSubmit()) {
-            e.preventDefault();
-            e.stopPropagation();
-        }
+        submitBtn.addEventListener('click', function(e) {
+            if (!lockSubmit()) {
+                e.preventDefault();
+                e.stopPropagation();
+            }
+        });
+
+        loginForm.addEventListener('submit', function(e) {
+            if (!lockSubmit()) {
+                e.preventDefault();
+                e.stopPropagation();
+            }
+        });
     });
 })();
 function openContactModal() {
@@ -513,9 +584,10 @@ document.addEventListener('DOMContentLoaded', function() {
         themeToggle.addEventListener('click', toggleTheme);
     }
 
-    // Attach footer icon and avatar modal triggers
-    document.querySelectorAll('.footer-icon[data-modal], img[data-modal]').forEach(function(icon) {
-        icon.addEventListener('click', function() {
+    // Attach modal triggers (footer icons, avatar, and any [data-modal] element)
+    document.querySelectorAll('[data-modal]').forEach(function(icon) {
+        icon.addEventListener('click', function(e) {
+            e.preventDefault();
             var modal = this.getAttribute('data-modal');
             if (modal === 'contact') openContactModal();
             else if (modal === 'cost') openCostModal();

--- a/web/static/demo-amsterdam.svg
+++ b/web/static/demo-amsterdam.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 120" preserveAspectRatio="xMidYMid slice" role="img" aria-label="Illustration of Amsterdam canal houses">
+  <defs>
+    <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#f6e2c2"/>
+      <stop offset="1" stop-color="#eec190"/>
+    </linearGradient>
+  </defs>
+  <rect width="160" height="120" fill="url(#sky)"/>
+  <!-- canal house 1 (stepped gable) -->
+  <g>
+    <rect x="16" y="44" width="34" height="76" fill="#b86e30"/>
+    <path d="M16 44 h34 v-6 h-7 v-6 h-7 v-6 h-6 v6 h-7 v6 h-7 z" fill="#9c5a20"/>
+    <rect x="22" y="54" width="9" height="12" fill="#fbf1dd"/>
+    <rect x="35" y="54" width="9" height="12" fill="#fbf1dd"/>
+    <rect x="22" y="74" width="9" height="12" fill="#fbf1dd"/>
+    <rect x="35" y="74" width="9" height="12" fill="#fbf1dd"/>
+    <rect x="28" y="98" width="11" height="22" fill="#6f3f1c"/>
+  </g>
+  <!-- canal house 2 (bell gable) -->
+  <g>
+    <rect x="54" y="34" width="40" height="86" fill="#cf9152"/>
+    <path d="M54 34 q20 -20 40 0 z" fill="#a8703a"/>
+    <rect x="61" y="44" width="11" height="13" fill="#fff6e6"/>
+    <rect x="77" y="44" width="11" height="13" fill="#fff6e6"/>
+    <rect x="61" y="66" width="11" height="13" fill="#fff6e6"/>
+    <rect x="77" y="66" width="11" height="13" fill="#fff6e6"/>
+    <rect x="61" y="88" width="11" height="13" fill="#fff6e6"/>
+    <rect x="77" y="88" width="11" height="13" fill="#fff6e6"/>
+    <rect x="67" y="104" width="14" height="16" fill="#7c4a22"/>
+  </g>
+  <!-- canal house 3 (triangular gable) -->
+  <g>
+    <rect x="98" y="50" width="36" height="70" fill="#a8581f"/>
+    <polygon points="98,50 116,36 134,50" fill="#8a4717"/>
+    <rect x="104" y="60" width="10" height="12" fill="#fbf1dd"/>
+    <rect x="118" y="60" width="10" height="12" fill="#fbf1dd"/>
+    <rect x="104" y="80" width="10" height="12" fill="#fbf1dd"/>
+    <rect x="118" y="80" width="10" height="12" fill="#fbf1dd"/>
+    <rect x="110" y="100" width="12" height="20" fill="#67380f"/>
+  </g>
+</svg>

--- a/web/static/demo-rotterdam.svg
+++ b/web/static/demo-rotterdam.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 120" preserveAspectRatio="xMidYMid slice" role="img" aria-label="Illustration of brick townhouses">
+  <defs>
+    <linearGradient id="sky3" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#f5dcbd"/>
+      <stop offset="1" stop-color="#e6b885"/>
+    </linearGradient>
+  </defs>
+  <rect width="160" height="120" fill="url(#sky3)"/>
+  <!-- townhouse 1 -->
+  <g>
+    <rect x="18" y="52" width="40" height="68" fill="#a8501f"/>
+    <polygon points="14,52 38,38 62,52" fill="#7f3a14"/>
+    <rect x="25" y="62" width="11" height="12" fill="#fbeede"/>
+    <rect x="40" y="62" width="11" height="12" fill="#fbeede"/>
+    <rect x="25" y="82" width="11" height="12" fill="#fbeede"/>
+    <rect x="40" y="82" width="11" height="12" fill="#fbeede"/>
+    <rect x="32" y="102" width="13" height="18" fill="#5e2c0f"/>
+  </g>
+  <!-- townhouse 2 (taller) -->
+  <g>
+    <rect x="62" y="42" width="40" height="78" fill="#c0703a"/>
+    <polygon points="58,42 82,28 106,42" fill="#94521f"/>
+    <rect x="69" y="52" width="11" height="12" fill="#fff4e6"/>
+    <rect x="84" y="52" width="11" height="12" fill="#fff4e6"/>
+    <rect x="69" y="72" width="11" height="12" fill="#fff4e6"/>
+    <rect x="84" y="72" width="11" height="12" fill="#fff4e6"/>
+    <rect x="76" y="98" width="13" height="22" fill="#6e3a16"/>
+  </g>
+  <!-- townhouse 3 -->
+  <g>
+    <rect x="106" y="56" width="40" height="64" fill="#9a481c"/>
+    <polygon points="102,56 126,42 150,56" fill="#763611"/>
+    <rect x="113" y="66" width="11" height="12" fill="#fbeede"/>
+    <rect x="128" y="66" width="11" height="12" fill="#fbeede"/>
+    <rect x="113" y="86" width="11" height="12" fill="#fbeede"/>
+    <rect x="128" y="86" width="11" height="12" fill="#fbeede"/>
+    <rect x="120" y="104" width="13" height="16" fill="#55280d"/>
+  </g>
+</svg>

--- a/web/static/demo-utrecht.svg
+++ b/web/static/demo-utrecht.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 120" preserveAspectRatio="xMidYMid slice" role="img" aria-label="Illustration of a modern apartment building">
+  <defs>
+    <linearGradient id="sky2" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#efe6d4"/>
+      <stop offset="1" stop-color="#dcc8a6"/>
+    </linearGradient>
+  </defs>
+  <rect width="160" height="120" fill="url(#sky2)"/>
+  <!-- low block left -->
+  <rect x="14" y="62" width="40" height="58" fill="#b58a5c"/>
+  <g fill="#fcf5e8">
+    <rect x="20" y="70" width="11" height="9"/><rect x="37" y="70" width="11" height="9"/>
+    <rect x="20" y="86" width="11" height="9"/><rect x="37" y="86" width="11" height="9"/>
+    <rect x="20" y="102" width="11" height="9"/><rect x="37" y="102" width="11" height="9"/>
+  </g>
+  <!-- tall tower center -->
+  <rect x="58" y="30" width="44" height="90" fill="#9c7546"/>
+  <g fill="#fff7ea">
+    <rect x="64" y="38" width="12" height="10"/><rect x="84" y="38" width="12" height="10"/>
+    <rect x="64" y="54" width="12" height="10"/><rect x="84" y="54" width="12" height="10"/>
+    <rect x="64" y="70" width="12" height="10"/><rect x="84" y="70" width="12" height="10"/>
+    <rect x="64" y="86" width="12" height="10"/><rect x="84" y="86" width="12" height="10"/>
+  </g>
+  <rect x="74" y="104" width="14" height="16" fill="#6f4f2a"/>
+  <!-- mid block right -->
+  <rect x="106" y="48" width="40" height="72" fill="#c39a68"/>
+  <g fill="#fcf5e8">
+    <rect x="112" y="56" width="11" height="9"/><rect x="129" y="56" width="11" height="9"/>
+    <rect x="112" y="72" width="11" height="9"/><rect x="129" y="72" width="11" height="9"/>
+    <rect x="112" y="88" width="11" height="9"/><rect x="129" y="88" width="11" height="9"/>
+  </g>
+</svg>

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -1167,3 +1167,320 @@ footer {
 .dashboard-filters .settings-grid {
     grid-template-columns: 1fr;
 }
+
+/* ===========================================================================
+   Public landing page (served at "/" for logged-out visitors)
+   Reuses the shared design tokens above; works in both light and dark themes.
+   =========================================================================== */
+.landing-body { padding: 0; }
+.landing-main,
+.landing-header,
+.landing-footer-inner {
+    max-width: 1080px;
+    margin: 0 auto;
+    padding-left: 1.25rem;
+    padding-right: 1.25rem;
+}
+
+/* Header */
+.landing-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+    position: sticky;
+    top: 0;
+    z-index: 60;
+    background: var(--bg);
+    background: color-mix(in srgb, var(--bg) 88%, transparent);
+    backdrop-filter: blur(8px);
+    border-bottom: 1px solid var(--hr);
+}
+@supports not (backdrop-filter: blur(8px)) {
+    .landing-header { background: var(--bg); }
+}
+.landing-brand {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.55rem;
+    text-decoration: none;
+    color: var(--fg);
+}
+.landing-brand-logo {
+    border-radius: 50%;
+    object-fit: cover;
+    flex-shrink: 0;
+}
+.landing-brand-name {
+    font-weight: 700;
+    font-size: 1.15rem;
+    letter-spacing: 0.01em;
+}
+.landing-nav {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+.landing-login-btn {
+    padding: 0.45rem 1.1rem;
+    font-size: 0.9rem;
+    font-weight: 600;
+    border-radius: 999px;
+}
+
+/* Generic section rhythm */
+.landing-section {
+    padding-top: 3rem;
+    padding-bottom: 1rem;
+}
+.landing-section-title {
+    font-size: 1.5rem;
+    text-align: center;
+    margin-bottom: 1.5rem;
+    color: var(--fg);
+}
+.landing-prose {
+    max-width: 640px;
+    margin: 0 auto;
+    text-align: center;
+    color: var(--subtitle);
+    font-size: 1.02rem;
+    line-height: 1.7;
+}
+/* Demo listings feed: keep the cards at a readable width like the real feed */
+.landing-demo-list {
+    max-width: 600px;
+    margin: 1.5rem auto 0;
+}
+.landing-demo-list .home-card-link { cursor: default; }
+
+/* Hero */
+.landing-hero {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+    align-items: center;
+    padding-top: 2.5rem;
+    padding-bottom: 1.5rem;
+}
+.landing-hero h1 {
+    font-size: 2.1rem;
+    line-height: 1.15;
+    margin-bottom: 0.9rem;
+}
+.landing-hl { color: var(--primary); white-space: nowrap; }
+.landing-hero-sub {
+    font-size: 1.08rem;
+    color: var(--subtitle);
+    line-height: 1.6;
+    max-width: 36rem;
+    margin-bottom: 1.5rem;
+}
+.landing-signup { margin-bottom: 1rem; max-width: 26rem; }
+.landing-signup .input-arrow-wrap input {
+    padding: 0.7rem 2.75rem 0.7rem 0.9rem;
+}
+.landing-cta-note {
+    margin-top: 0.6rem;
+    margin-bottom: 0;
+    font-size: 0.82rem;
+    color: var(--subtitle);
+}
+.landing-ios-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    font-size: 0.92rem;
+    text-decoration: none;
+    color: var(--link);
+}
+.landing-ios-link:hover { color: var(--link-hover); text-decoration: underline; }
+.landing-ios-link svg { width: 18px; height: 18px; }
+/* Hide iOS-app links on Android (app is iOS-only). Set in <head>, no flash. */
+html.is-android [data-ios-link] { display: none; }
+.landing-hero-art {
+    display: none; /* hidden on mobile; shown once the hero is two-column */
+    justify-content: center;
+}
+.landing-hero-avatar {
+    width: min(220px, 60vw);
+    height: auto;
+    border-radius: 50%;
+    object-fit: cover;
+    box-shadow: 0 12px 40px var(--glow), 0 0 0 1px var(--card-border);
+}
+
+/* Stats strip */
+.landing-stats {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 1rem;
+    margin-top: 1.5rem;
+    padding: 1.25rem 1rem;
+    background: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: 12px;
+}
+.landing-stat {
+    flex: 1 1 8rem;
+    text-align: center;
+    min-width: 7rem;
+}
+.landing-stat-value {
+    display: block;
+    font-size: 1.6rem;
+    font-weight: 800;
+    color: var(--primary);
+    line-height: 1.1;
+}
+.landing-stat-label {
+    font-size: 0.8rem;
+    color: var(--subtitle);
+}
+
+/* How it works */
+.landing-steps {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1.25rem;
+}
+.landing-step {
+    background: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: 12px;
+    padding: 1.5rem;
+    text-align: center;
+}
+.landing-step-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    background: var(--msg-bg);
+    color: var(--primary);
+    margin-bottom: 0.9rem;
+}
+.landing-step-icon svg { width: 24px; height: 24px; }
+.landing-step h3 { font-size: 1.1rem; margin-bottom: 0.4rem; color: var(--fg); }
+.landing-step p { color: var(--subtitle); margin-bottom: 0; font-size: 0.95rem; }
+
+/* FAQ */
+.landing-faq { max-width: 720px; margin-left: auto; margin-right: auto; }
+.landing-faq-item {
+    border: 1px solid var(--card-border);
+    border-radius: 10px;
+    background: var(--card-bg);
+    margin-bottom: 0.6rem;
+    overflow: hidden;
+}
+.landing-faq-item summary {
+    list-style: none;
+    cursor: pointer;
+    padding: 0.9rem 1.1rem;
+    font-weight: 600;
+    color: var(--fg);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+}
+.landing-faq-item summary::-webkit-details-marker { display: none; }
+.landing-faq-item summary::after {
+    content: "+";
+    color: var(--primary);
+    font-size: 1.25rem;
+    line-height: 1;
+    flex-shrink: 0;
+}
+.landing-faq-item[open] summary::after { content: "\2212"; }
+.landing-faq-item p {
+    padding: 0 1.1rem 1rem;
+    margin: 0;
+    color: var(--subtitle);
+    font-size: 0.95rem;
+    line-height: 1.6;
+}
+.landing-faq-item a { color: var(--link); }
+
+/* Final CTA */
+.landing-final-cta {
+    text-align: center;
+    margin: 3.5rem auto 1rem;
+    padding: 2.5rem 1.5rem;
+    background: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: 16px;
+}
+.landing-final-cta h2 { font-size: 1.6rem; margin-bottom: 0.5rem; }
+.landing-final-cta p { color: var(--subtitle); margin-bottom: 1.25rem; }
+.landing-final-btn {
+    padding: 0.7rem 1.75rem;
+    font-size: 1rem;
+    font-weight: 600;
+    border-radius: 999px;
+}
+
+/* Footer */
+.landing-footer {
+    margin-top: 3rem;
+    border-top: 1px solid var(--hr);
+    background: var(--card-bg);
+    padding: 2rem 0 2.5rem;
+}
+.landing-footer-inner {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    justify-content: space-between;
+    align-items: flex-start;
+}
+.landing-footer-brand {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+}
+.landing-footer-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem 1.25rem;
+}
+.landing-footer-links a {
+    color: var(--subtitle);
+    text-decoration: none;
+    font-size: 0.9rem;
+}
+.landing-footer-links a:hover { color: var(--link); text-decoration: underline; }
+.landing-footer-credit {
+    max-width: 1080px;
+    margin: 1.25rem auto 0;
+    padding: 0 1.25rem;
+    font-size: 0.78rem;
+    color: var(--subtitle);
+    opacity: 0.8;
+}
+.landing-footer-credit a { color: var(--link); }
+
+/* Tablet / desktop */
+@media (min-width: 720px) {
+    .landing-hero h1 { font-size: 2.6rem; }
+    .landing-steps { grid-template-columns: repeat(3, 1fr); }
+    .landing-footer-inner { flex-direction: row; align-items: center; }
+}
+@media (min-width: 900px) {
+    .landing-hero {
+        grid-template-columns: 1.1fr 0.9fr;
+        gap: 2.5rem;
+        padding-top: 3.5rem;
+    }
+    .landing-hero h1 { font-size: 3rem; }
+    .landing-section-title { font-size: 1.75rem; }
+    .landing-hero-art { display: flex; }
+}

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="apple-itunes-app" content="app-id=6760269825">
-    <title>Hestia – {{ title }}</title>
+    <title>{% block title %}Hestia – {{ title }}{% endblock %}</title>
     <link rel="apple-touch-icon" sizes="57x57" href="/static/apple-icon-57x57.png">
     <link rel="apple-touch-icon" sizes="60x60" href="/static/apple-icon-60x60.png">
     <link rel="apple-touch-icon" sizes="72x72" href="/static/apple-icon-72x72.png">
@@ -27,9 +27,11 @@
     <script src="https://unpkg.com/lucide@0.563.0/dist/umd/lucide.min.js"
             integrity="sha384-aRB6X3zBuyu5EQF6GZFp0RCYdOwxYAOdFk4nViPfqSXYxc+MrZlqbM+nUYRwDQn1"
             crossorigin="anonymous"></script>
+    {% block extra_head %}{% endblock %}
 </head>
-<body class="{% if contact_only %}contact-only{% endif %}">
+<body class="{% if contact_only %}contact-only{% endif %}{% if landing %} landing-body{% endif %}">
     {% block content %}{% endblock %}
+    {% if not landing %}
     <div class="toolbar-buttons">
         <button type="button" class="lang-toggle" aria-label="Switch language" title="Switch language">
             <span class="lang-label"></span>
@@ -47,6 +49,7 @@
             {% endif %}
         </div>
     </footer>
+    {% endif %}
     <div class="modal-overlay" id="contact-modal">
         <div class="modal">
             <button class="modal-close" data-close-modal="contact">&times;</button>

--- a/web/templates/landing.html
+++ b/web/templates/landing.html
@@ -1,0 +1,293 @@
+{% extends "base.html" %}
+{% block title %}Hestia – Free rental-home alerts for the Netherlands{% endblock %}
+{% block extra_head %}
+    <meta name="description" content="Hestia monitors the major Dutch rental sites and notifies you within minutes when a new listing matches your filters. Free, fast, and built to help you be first in a tight market.">
+    <link rel="canonical" href="{{ base_url }}/">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Hestia">
+    <meta property="og:title" content="Hestia – Free rental-home alerts for the Netherlands">
+    <meta property="og:description" content="Hestia watches the major Dutch rental sites for you and sends a notification within minutes of a new match. Free, fast, no account needed.">
+    <meta property="og:url" content="{{ base_url }}/">
+    <meta property="og:image" content="{{ base_url }}/avatar">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Hestia – Free rental-home alerts for the Netherlands">
+    <meta name="twitter:description" content="Get notified within minutes of a new Dutch rental listing that matches your filters. Free.">
+    <meta name="twitter:image" content="{{ base_url }}/avatar">
+{% endblock %}
+{% block content %}
+<header class="landing-header">
+    <a class="landing-brand" href="/" aria-label="Hestia home">
+        <img src="/avatar" alt="" class="landing-brand-logo" width="40" height="40">
+        <span class="landing-brand-name">Hestia</span>
+    </a>
+    <nav class="landing-nav" aria-label="Primary">
+        <button type="button" class="lang-toggle" aria-label="Switch language" title="Switch language">
+            <span class="lang-label"></span>
+        </button>
+        <button type="button" class="theme-toggle" aria-label="Toggle dark mode" title="Toggle dark mode">
+            <span class="theme-icon"></span>
+        </button>
+        <button type="button" class="btn landing-login-btn" data-open-login data-i18n="landing_login">Log in</button>
+    </nav>
+</header>
+
+<main class="landing-main">
+    <!-- Hero -->
+    <section class="landing-hero" aria-labelledby="landing-hero-title">
+        <div class="landing-hero-text">
+            <h1 id="landing-hero-title" data-i18n-html="landing_hero_title">Find your next rental home, <span class="landing-hl">for free</span></h1>
+            <p class="landing-hero-sub" data-i18n="landing_hero_sub">Hestia watches Dutch rental sites for you and sends a notification within minutes of a new listing that matches your filters. Be the first to respond!</p>
+            <form method="post" action="/login" class="landing-signup" id="signup">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                {% if message %}<div class="message">{{ message }}</div>{% endif %}
+                <div class="input-arrow-wrap">
+                    <input type="email" name="email" id="email" placeholder="hello@hestia.bot" aria-label="Email address" required>
+                    <button type="submit" class="btn-arrow" aria-label="Continue" data-i18n-title="continue_aria">&#x2192;</button>
+                </div>
+                <p class="landing-cta-note" data-i18n="landing_cta_note">Enter your email to get started. We only use it to save your preferences.</p>
+            </form>
+            <a class="landing-ios-link" data-ios-link href="https://apps.apple.com/app/id6760269825" target="_blank" rel="noopener noreferrer">
+                <i data-lucide="smartphone" aria-hidden="true"></i>
+                <span data-i18n="landing_ios">Or get the iOS app</span>
+            </a>
+        </div>
+        <div class="landing-hero-art" aria-hidden="true">
+            <img src="/avatar" alt="" class="landing-hero-avatar" width="220" height="220">
+        </div>
+    </section>
+
+    <!-- Trust / stats strip -->
+    <section class="landing-stats" aria-label="Hestia at a glance">
+        <div class="landing-stat">
+            <span class="landing-stat-value" id="landing-stat-homes">…</span>
+            <span class="landing-stat-label" data-i18n="stats_total_homes">Homes found</span>
+        </div>
+        <div class="landing-stat">
+            <span class="landing-stat-value" id="landing-stat-users">…</span>
+            <span class="landing-stat-label" data-i18n="stats_total_subscribers">Users</span>
+        </div>
+        <div class="landing-stat">
+            <span class="landing-stat-value" id="landing-stat-today">…</span>
+            <span class="landing-stat-label" data-i18n="stats_homes_today">Homes found today</span>
+        </div>
+    </section>
+
+    <!-- How it works -->
+    <section class="landing-section" aria-labelledby="landing-how-title">
+        <h2 id="landing-how-title" class="landing-section-title" data-i18n="landing_how_title">How it works</h2>
+        <ol class="landing-steps">
+            <li class="landing-step">
+                <span class="landing-step-icon"><i data-lucide="sliders-horizontal" aria-hidden="true"></i></span>
+                <h3 data-i18n="landing_step1_title">Set your filters</h3>
+                <p data-i18n="landing_step1_text">Choose your cities, price range and minimum size. Adjust them anytime.</p>
+            </li>
+            <li class="landing-step">
+                <span class="landing-step-icon"><i data-lucide="bell-ring" aria-hidden="true"></i></span>
+                <h3 data-i18n="landing_step2_title">Get notified in minutes</h3>
+                <p data-i18n="landing_step2_text">The moment a matching home appears on any monitored site, Hestia lets you know.</p>
+            </li>
+            <li class="landing-step">
+                <span class="landing-step-icon"><i data-lucide="rocket" aria-hidden="true"></i></span>
+                <h3 data-i18n="landing_step3_title">Be first to respond</h3>
+                <p data-i18n="landing_step3_text">In a tight market, minutes matter. Reach out before the crowd does.</p>
+            </li>
+        </ol>
+    </section>
+
+
+    <!-- Demo listings feed -->
+    <section class="landing-section" aria-labelledby="landing-demo-title">
+        <h2 id="landing-demo-title" class="landing-section-title" data-i18n="landing_demo_title">A preview of your feed</h2>
+        <p class="landing-prose" data-i18n="landing_demo_sub">Set your filters and real matches appear within minutes of going online.</p>
+        <div class="landing-demo-list">
+            <div class="homes-list">
+                <div class="home-card">
+                    <div class="home-card-link">
+                        <div class="home-card-media has-image">
+                            <img class="home-card-image" src="/static/demo-amsterdam.svg" alt="" width="144" height="108">
+                            <div class="home-card-placeholder"><i data-lucide="home" style="width:28px;height:28px"></i></div>
+                        </div>
+                        <div class="home-card-body">
+                            <div class="home-card-address">Prinsengracht 1012</div>
+                            <div class="home-card-city">Amsterdam</div>
+                            <div class="home-card-meta">
+                                <span class="home-card-meta-left">
+                                    <span class="home-card-price">€1750</span>
+                                    <span class="home-card-sqm">62 m2</span>
+                                </span>
+                            </div>
+                            <div class="home-card-date" data-i18n="landing_demo_time1">1 minute ago</div>
+                        </div>
+                    </div>
+                </div>
+                <div class="home-card">
+                    <div class="home-card-link">
+                        <div class="home-card-media has-image">
+                            <img class="home-card-image" src="/static/demo-utrecht.svg" alt="" width="144" height="108">
+                            <div class="home-card-placeholder"><i data-lucide="home" style="width:28px;height:28px"></i></div>
+                        </div>
+                        <div class="home-card-body">
+                            <div class="home-card-address">Lange Nieuwstraat 88</div>
+                            <div class="home-card-city">Utrecht</div>
+                            <div class="home-card-meta">
+                                <span class="home-card-meta-left">
+                                    <span class="home-card-price">€1395</span>
+                                    <span class="home-card-sqm">55 m2</span>
+                                </span>
+                            </div>
+                            <div class="home-card-date" data-i18n="landing_demo_time2">6 minutes ago</div>
+                        </div>
+                    </div>
+                </div>
+                <div class="home-card">
+                    <div class="home-card-link">
+                        <div class="home-card-media has-image">
+                            <img class="home-card-image" src="/static/demo-rotterdam.svg" alt="" width="144" height="108">
+                            <div class="home-card-placeholder"><i data-lucide="home" style="width:28px;height:28px"></i></div>
+                        </div>
+                        <div class="home-card-body">
+                            <div class="home-card-address">Witte de Withstraat 24</div>
+                            <div class="home-card-city">Rotterdam</div>
+                            <div class="home-card-meta">
+                                <span class="home-card-meta-left">
+                                    <span class="home-card-price">€1520</span>
+                                    <span class="home-card-sqm">70 m2</span>
+                                </span>
+                            </div>
+                            <div class="home-card-date" data-i18n="landing_demo_time3">7 minutes ago</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Coverage & trust -->
+    <section class="landing-section landing-coverage" aria-labelledby="landing-coverage-title">
+        <h2 id="landing-coverage-title" class="landing-section-title" data-i18n="landing_coverage_title">Broad, deduplicated coverage</h2>
+        <p class="landing-prose" data-i18n="landing_coverage_text">Hestia continuously monitors a wide range of major Dutch rental platforms and housing agencies, and removes duplicate listings across sources, so you see each home only once.</p>
+    </section>
+
+    <!-- Story -->
+    <section class="landing-section landing-story" aria-labelledby="landing-story-title">
+        <h2 id="landing-story-title" class="landing-section-title" data-i18n="landing_story_title">Why Hestia exists</h2>
+        <p class="landing-prose" data-i18n="landing_story_text">I built Hestia for myself while looking for a place after my studies: I'm lazy and like to automate as much as I can. Once I'd found something I forwarded it to a few friends, who forwarded it to theirs, and on it went until today: by now I've helped thousands of people find a home!</p>
+    </section>
+
+    <!-- FAQ -->
+    <section class="landing-section landing-faq" aria-labelledby="landing-faq-title">
+        <h2 id="landing-faq-title" class="landing-section-title" data-i18n="landing_faq_title">Frequently Asked Questions</h2>
+        <details class="landing-faq-item">
+            <summary data-i18n="faq_q_what">What is Hestia?</summary>
+            <p data-i18n="faq_a_what">Hestia is a home-finding service that monitors websites and notifies you about new matches within your filters.</p>
+        </details>
+        <details class="landing-faq-item">
+            <summary data-i18n="faq_q_free">Hestia is free?</summary>
+            <p data-i18n="faq_a_free">Yes. I built Hestia for myself and once we found a home, I thought it would be nice to share it with others!</p>
+        </details>
+        <details class="landing-faq-item">
+            <summary data-i18n="faq_q_speed">How quick is Hestia?</summary>
+            <p data-i18n="faq_a_speed">Notifications should arrive within 10 minutes.</p>
+        </details>
+        <details class="landing-faq-item">
+            <summary data-i18n="faq_q_buy">Does this work if I want to buy a home?</summary>
+            <p data-i18n="faq_a_buy">Not yet, but who knows what I might build when I am looking to buy something myself!</p>
+        </details>
+        <details class="landing-faq-item">
+            <summary data-i18n="faq_q_app">Is there an app?</summary>
+            <p data-i18n-html="faq_a_app">Yes! Hestia is available as an <a href="https://apps.apple.com/app/id6760269825" target="_blank" rel="noopener noreferrer">iPhone app</a>.</p>
+        </details>
+    </section>
+
+    <!-- Final CTA -->
+    <section class="landing-final-cta" aria-labelledby="landing-final-title">
+        <h2 id="landing-final-title" data-i18n="landing_final_title">Ready to find your new home?</h2>
+        <p data-i18n="landing_final_sub">Did I mention it's free? Enter your email and find your new home!</p>
+        <button type="button" class="btn landing-final-btn" data-open-login data-i18n="landing_final_btn">Get started</button>
+    </section>
+</main>
+
+<footer class="landing-footer">
+    <div class="landing-footer-inner">
+        <div class="landing-footer-brand">
+            <img src="/avatar" alt="" class="landing-brand-logo" width="32" height="32">
+            <div>
+                <span class="landing-brand-name">Hestia</span>
+            </div>
+        </div>
+        <nav class="landing-footer-links" aria-label="Footer">
+            <a href="#" data-modal="contact" data-i18n="landing_footer_contact">Contact</a>
+            <a href="/privacy" data-i18n="landing_footer_privacy">Privacy &amp; cookies</a>
+            <a href="https://github.com/wtfloris/hestia" target="_blank" rel="noopener noreferrer" data-i18n="landing_footer_source">GitHub</a>
+            <a href="https://apps.apple.com/app/id6760269825" target="_blank" rel="noopener noreferrer" data-ios-link data-i18n="landing_footer_ios">iOS app</a>
+        </nav>
+    </div>
+    <p class="landing-footer-credit">
+        <span data-i18n="contact_avatar_credit">Hestia artwork courtesy of </span>
+        <a href="https://instagram.com/elisa_tulli" target="_blank" rel="noopener noreferrer">@elisa_tulli</a>
+    </p>
+</footer>
+
+<div class="modal-overlay" id="login-modal" role="dialog" aria-modal="true" aria-labelledby="login-modal-title">
+    <div class="modal">
+        <button class="modal-close" type="button" data-close-login aria-label="Close">&times;</button>
+        <h2 id="login-modal-title" data-i18n="landing_login_title">Log in or sign up</h2>
+        <p class="subtitle" data-i18n="landing_login_desc">Enter your email and we'll send you a login link. No password needed.</p>
+        <form method="post" action="/login" id="login-form-modal">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <div class="input-arrow-wrap">
+                <input type="email" name="email" id="login-email" placeholder="hello@hestia.bot" aria-label="Email address" required>
+                <button type="submit" class="btn-arrow" aria-label="Continue" data-i18n-title="continue_aria">&#x2192;</button>
+            </div>
+            <p class="landing-cta-note" data-i18n="landing_cta_note">Enter your email to get started. We only use it to save your preferences.</p>
+        </form>
+    </div>
+</div>
+
+<script nonce="{{ g.csp_nonce }}">
+(function() {
+    // Populate the trust strip from the public statistics endpoint.
+    function fmt(n) {
+        try { return Number(n).toLocaleString(); } catch (e) { return String(n); }
+    }
+    fetch('/api/statistics')
+        .then(function(r) { return r.ok ? r.json() : null; })
+        .then(function(data) {
+            if (!data || data.error) return;
+            var homes = document.getElementById('landing-stat-homes');
+            var users = document.getElementById('landing-stat-users');
+            var today = document.getElementById('landing-stat-today');
+            if (homes && typeof data.total_homes === 'number') homes.textContent = fmt(data.total_homes);
+            if (users && typeof data.total_subscribers === 'number') users.textContent = fmt(data.total_subscribers);
+            if (today && typeof data.homes_today === 'number') today.textContent = fmt(data.homes_today);
+        })
+        .catch(function() { /* leave placeholders */ });
+
+    // Login modal: opened by the header button and the final CTA.
+    var loginModal = document.getElementById('login-modal');
+    function openLogin() {
+        if (!loginModal) return;
+        loginModal.classList.add('visible');
+        var input = document.getElementById('login-email');
+        if (input) setTimeout(function() { input.focus(); }, 50);
+    }
+    function closeLogin() {
+        if (loginModal) loginModal.classList.remove('visible');
+    }
+    document.querySelectorAll('[data-open-login]').forEach(function(btn) {
+        btn.addEventListener('click', openLogin);
+    });
+    document.querySelectorAll('[data-close-login]').forEach(function(btn) {
+        btn.addEventListener('click', closeLogin);
+    });
+    if (loginModal) {
+        loginModal.addEventListener('click', function(e) {
+            if (e.target === loginModal) closeLogin();
+        });
+    }
+    document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape' && loginModal && loginModal.classList.contains('visible')) closeLogin();
+    });
+})();
+</script>
+{% endblock %}

--- a/web/templates/privacy.html
+++ b/web/templates/privacy.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Hestia – Privacy Policy</title>
+<title>Hestia – Privacy &amp; Cookie Statement</title>
 <style>
   body {
     font-family: -apple-system, BlinkMacSystemFont, sans-serif;
@@ -16,21 +16,45 @@
   }
   h1 { font-size: 1.5em; }
   h2 { font-size: 1.15em; margin-top: 1.5em; }
+  a { color: #b06828; }
+  .note {
+    font-size: 0.85em;
+    background: #f8ecd6;
+    border: 1px solid #e4c488;
+    border-radius: 6px;
+    padding: 10px 12px;
+    color: #6a4420;
+  }
   @media (prefers-color-scheme: dark) {
     body { color: #EDE4D6; background: #161020; }
+    a { color: #e8a84c; }
+    .note { background: #2c1e14; border-color: #c07830; color: #f0d4a0; }
   }
 </style>
 </head>
 <body>
 
-<h1>Privacy Policy</h1>
-<p><strong>Last updated:</strong> 6 March 2026</p>
+<h1>Privacy &amp; Cookie Statement</h1>
+<p><strong>Last updated:</strong> 15 June 2026</p>
 
-<h2>Data collection</h2>
-<p>Hestia collects a random device identifier with your filter settings (price range, cities, agencies, minimum size). If you enable notifications, Hestia saves a notification token. This is the bare minimum required to make the app work. I don't care which homes you view or not: Hestia doesn't use any analytics and doesn't collect any data that would be worth selling. I don't want your data so Hestia doesn't collect it.</p>
+<!-- TODO (owner): This statement is a practical, plain-language summary. Have it
+     reviewed for full GDPR/AVG compliance (controller identity, legal basis,
+     retention periods, data-processor agreements with Brevo) before relying on it
+     for partner/affiliate approvals. -->
+<p class="note">This is a plain-language summary of how Hestia handles your data. Hestia is a free, privacy-respecting passion project and collects as little as possible.</p>
+
+<h2>Website &amp; email</h2>
+<p>To use the Hestia website you sign in with your email address. Hestia stores your email address together with your filter settings (price range, cities, agencies, minimum size) so it can send you matching listings. If you link Telegram, a Telegram identifier is stored to deliver notifications there. That is all Hestia keeps about you.</p>
+<p>Your email address is used only to send you login links and (if enabled) notifications. It is never sold or shared for advertising. Login links are sent through our email provider (Brevo) purely to deliver the message.</p>
+
+<h2>Cookies</h2>
+<p>Hestia uses a single, strictly necessary cookie (<code>hestia_session</code>) to keep you logged in after you click your login link. It contains only your signed email address and is not used for tracking or advertising. Your theme and language preferences are stored locally in your browser (local storage), not in a cookie, and never leave your device. Hestia uses no analytics or third-party tracking cookies.</p>
+
+<h2>App data collection</h2>
+<p>The Hestia iOS app collects a random device identifier with your filter settings (price range, cities, agencies, minimum size). If you enable notifications, Hestia saves a notification token. This is the bare minimum required to make the app work. I don't care which homes you view or not: Hestia doesn't use any analytics and doesn't collect any data that would be worth selling. I don't want your data so Hestia doesn't collect it.</p>
 
 <h2>Deletion</h2>
-<p>Contact me through hestia@flori.sh to have your data removed. However, since there is no personal data collected, it'll be a bit hard to identify which database row is yours to be removed. We'll see how it goes!</p>
+<p>Contact me through <a href="mailto:hestia@flori.sh">hestia@flori.sh</a> to have your data removed. For website accounts, mention the email address you signed up with so I can find and delete your row. For the app, since there is no personal data collected, it'll be a bit hard to identify which database row is yours to be removed. We'll see how it goes!</p>
 
 </body>
 </html>

--- a/web/tests/test_app.py
+++ b/web/tests/test_app.py
@@ -142,7 +142,7 @@ class TestLandingPage:
     def test_get_index_contains_login_form(self, client):
         resp = client.get("/")
         html = resp.data.decode()
-        assert '<form method="post" action="/login">' in html
+        assert 'action="/login"' in html
         assert 'type="email"' in html
         assert "Hestia" in html
 
@@ -957,7 +957,7 @@ class TestApiPreviewImageAuthParity:
         assert "Location" not in resp.headers
 
 
-class TestApiStatisticsAndDonationAuth:
+class TestApiStatisticsAndDonationPublic:
     @patch("hestia_web.app.get_db")
     def test_api_statistics_with_valid_cookie_returns_200_json(self, mock_get_db, client):
         set_session(client, email="user@example.com")
@@ -985,7 +985,7 @@ class TestApiStatisticsAndDonationAuth:
         conn = MagicMock()
         conn.__enter__ = MagicMock(return_value=conn)
         conn.__exit__ = MagicMock(return_value=False)
-        conn.cursor.side_effect = [auth_cur, stats_cur]
+        conn.cursor.return_value = stats_cur
         mock_get_db.return_value = conn
 
         resp = client.get("/api/statistics", follow_redirects=False)
@@ -1024,7 +1024,7 @@ class TestApiStatisticsAndDonationAuth:
         conn = MagicMock()
         conn.__enter__ = MagicMock(return_value=conn)
         conn.__exit__ = MagicMock(return_value=False)
-        conn.cursor.side_effect = [auth_cur, stats_cur]
+        conn.cursor.return_value = stats_cur
         mock_get_db.return_value = conn
 
         resp = client.get("/api/statistics", headers={"X-Device-Id": VALID_DEVICE_ID}, follow_redirects=False)
@@ -1032,18 +1032,31 @@ class TestApiStatisticsAndDonationAuth:
         assert resp.is_json
         assert resp.get_json()["total_homes"] == 42
 
-    def test_api_statistics_without_auth_returns_401_json(self, client):
-        resp = client.get("/api/statistics", follow_redirects=False)
-        assert resp.status_code == 401
-        assert resp.is_json
-        assert resp.get_json() == {"error": "unauthorized"}
-        assert "Location" not in resp.headers
+    @patch("hestia_web.app.get_db")
+    def test_api_statistics_without_auth_is_public(self, mock_get_db, client):
+        stats_cur = MagicMock()
+        stats_cur.__enter__ = MagicMock(return_value=stats_cur)
+        stats_cur.__exit__ = MagicMock(return_value=False)
+        stats_cur.fetchone.side_effect = [
+            {"cnt": 7},
+            {"cnt": 1},
+            {"cnt": 3},
+            {"cnt": 2},
+        ]
+        stats_cur.fetchall.side_effect = [
+            [{"city": "Amsterdam", "count": 5}],
+            [{"agency": "rebo", "count": 4}],
+        ]
+        conn = MagicMock()
+        conn.__enter__ = MagicMock(return_value=conn)
+        conn.__exit__ = MagicMock(return_value=False)
+        conn.cursor.return_value = stats_cur
+        mock_get_db.return_value = conn
 
-    def test_api_statistics_with_invalid_device_id_returns_401_json(self, client):
-        resp = client.get("/api/statistics", headers={"X-Device-Id": "not-a-uuid"}, follow_redirects=False)
-        assert resp.status_code == 401
+        resp = client.get("/api/statistics", follow_redirects=False)
+        assert resp.status_code == 200
         assert resp.is_json
-        assert resp.get_json() == {"error": "unauthorized"}
+        assert resp.get_json()["total_homes"] == 7
         assert "Location" not in resp.headers
 
     @patch("hestia_web.app.get_db")
@@ -1061,7 +1074,7 @@ class TestApiStatisticsAndDonationAuth:
         conn = MagicMock()
         conn.__enter__ = MagicMock(return_value=conn)
         conn.__exit__ = MagicMock(return_value=False)
-        conn.cursor.side_effect = [auth_cur, donation_cur]
+        conn.cursor.return_value = donation_cur
         mock_get_db.return_value = conn
 
         resp = client.get("/api/donation-link", follow_redirects=False)
@@ -1082,7 +1095,7 @@ class TestApiStatisticsAndDonationAuth:
         conn = MagicMock()
         conn.__enter__ = MagicMock(return_value=conn)
         conn.__exit__ = MagicMock(return_value=False)
-        conn.cursor.side_effect = [auth_cur, donation_cur]
+        conn.cursor.return_value = donation_cur
         mock_get_db.return_value = conn
 
         resp = client.get("/api/donation-link", headers={"X-Device-Id": VALID_DEVICE_ID}, follow_redirects=False)
@@ -1090,18 +1103,19 @@ class TestApiStatisticsAndDonationAuth:
         assert resp.is_json
         assert resp.get_json() == {"url": "https://example.com/donate"}
 
-    def test_api_donation_link_without_auth_returns_401_json(self, client):
-        resp = client.get("/api/donation-link", follow_redirects=False)
-        assert resp.status_code == 401
-        assert resp.is_json
-        assert resp.get_json() == {"error": "unauthorized"}
-        assert "Location" not in resp.headers
+    @patch("hestia_web.app.get_db")
+    def test_api_donation_link_without_auth_is_public(self, mock_get_db, client):
+        donation_cur = make_mock_cursor(fetchone_value={"donation_link": "https://example.com/donate"})
+        conn = MagicMock()
+        conn.__enter__ = MagicMock(return_value=conn)
+        conn.__exit__ = MagicMock(return_value=False)
+        conn.cursor.return_value = donation_cur
+        mock_get_db.return_value = conn
 
-    def test_api_donation_link_with_invalid_device_id_returns_401_json(self, client):
-        resp = client.get("/api/donation-link", headers={"X-Device-Id": "not-a-uuid"}, follow_redirects=False)
-        assert resp.status_code == 401
+        resp = client.get("/api/donation-link", follow_redirects=False)
+        assert resp.status_code == 200
         assert resp.is_json
-        assert resp.get_json() == {"error": "unauthorized"}
+        assert resp.get_json() == {"url": "https://example.com/donate"}
         assert "Location" not in resp.headers
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What

Replaces the bare login page at `/` with a substantial, public, no-login landing page that sits as a shopfront in front of the existing tool. The email magic-link signup is preserved as the call to action; the gate is unchanged.

## Sections
- Hero with value proposition, email signup, and an iOS app link
- Stats strip (live counts from `/api/statistics`)
- How it works (3 steps)
- A preview of the feed: three demo listing cards using the real `home-card` markup, with self-hosted SVG house illustrations
- Coverage, origin story, FAQ, final CTA, footer
- Login modal opened from the header "Log in" button and the final CTA

## Notes
- Built on the existing design system: reuses the same CSS tokens, components, header toggles, and the existing i18n (EN/NL) and dark/light theme mechanisms. No new dependencies.
- `index()` now renders `landing.html` for logged-out visitors; logged-in users still go straight to the dashboard. Logout lands on the new page.
- `/api/statistics` and `/api/donation-link` are now public (aggregate/non-sensitive data only) so the trust strip works without a session.
- iOS app links are hidden on Android (UA detection set in `<head>`, fails open).
- SEO: title, meta description, Open Graph/Twitter tags, semantic headings, indexable copy.
- Privacy page expanded with website-email and cookie sections.
- 141 web tests pass.

## TODO for owner
- The privacy/cookie statement is a plain-language summary; have it reviewed for full GDPR/AVG compliance before relying on it for partner approvals.
- Optional: a wide 1200x630 social/OG image (currently uses the round avatar).