### PR TITLE
Add Your House scraper

### DIFF
--- a/docker/docker-compose-dev.yml
+++ b/docker/docker-compose-dev.yml
@@ -347,6 +347,12 @@ services:
     environment:
       - HESTIA_TARGET=woonmatchwaterland
 
+  hestia-scraper-yourhouse-dev:
+    <<: *scraper-dev-base
+    container_name: hestia-scraper-yourhouse-dev
+    environment:
+      - HESTIA_TARGET=yourhouse
+
   hestia-database-dev:
     container_name: hestia-database-dev
     healthcheck:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -347,6 +347,12 @@ services:
     environment:
       - HESTIA_TARGET=woonmatchwaterland
 
+  hestia-scraper-yourhouse:
+    <<: *scraper-base
+    container_name: hestia-scraper-yourhouse
+    environment:
+      - HESTIA_TARGET=yourhouse
+
   hestia-database:
     container_name: hestia-database
     healthcheck:

--- a/hestia/hestia_utils/parser.py
+++ b/hestia/hestia_utils/parser.py
@@ -147,6 +147,8 @@ class HomeResults:
             self.parse_beumer(raw)
         elif source == "nederwoon":
             self.parse_nederwoon(raw)
+        elif source == "yourhouse":
+            self.parse_yourhouse(raw)
         else:
             raise ValueError(f"Unknown source: {source}")
 
@@ -1375,3 +1377,68 @@ class HomeResults:
                         continue
 
                     add_home(address, city, link.get("href", ""), price_match.group(1), card_text)
+
+    def parse_yourhouse(self, r: requests.models.Response):
+        soup = BeautifulSoup(r.content, "html.parser")
+
+        for res in soup.select("article.object"):
+            link = res.select_one("a.sys-property-link[href]")
+            heading = res.select_one("h2")
+            if not link or not heading:
+                continue
+
+            href = str(link["href"])
+            # Only rental listings (skip /woningaanbod/koop/...)
+            if "/huur/" not in href:
+                continue
+
+            # The heading is prefixed with the listing status, e.g.
+            # "Te huur: ...", "Verhuurd: ...", "Onder optie: ...". Only the
+            # "Te huur" listings are actually available.
+            heading_text = " ".join(heading.get_text(" ", strip=True).split())
+            if ":" not in heading_text:
+                continue
+            status, _, location = heading_text.partition(":")
+            if status.strip().lower() != "te huur":
+                continue
+
+            # location is "<street> <number>, <postcode> <city>"
+            if "," not in location:
+                continue
+            address, _, city = location.partition(",")
+            address = address.strip()
+            if not re.search(r"\d", address):
+                continue
+            city = re.sub(r"^\d{4}\s?[A-Za-z]{2}\s+", "", city.strip()).strip()
+            if not city:
+                continue
+
+            price_tag = res.select_one(".obj_price")
+            if not price_tag:
+                continue
+            amount_match = re.search(r"(\d[\d\.]*)", price_tag.get_text(" ", strip=True))
+            if not amount_match:
+                continue
+            price = amount_match.group(1).replace(".", "")
+            if not price.isdigit():
+                continue
+
+            home = Home(agency="yourhouse")
+            home.address = address
+            home.city = city
+            home.url = parse.urljoin("https://your-house.nl", href.split("?")[0])
+            home.price = int(price)
+
+            # The card has no floor area, but it lists the price per m², so the
+            # surface area can be recovered as price / price-per-m².
+            ppm_tag = res.select_one(".obj_pricepersquaremeter")
+            if ppm_tag:
+                ppm_match = re.search(r"(\d+(?:,\d+)?)", ppm_tag.get_text(" ", strip=True))
+                if ppm_match:
+                    ppm = float(ppm_match.group(1).replace(",", "."))
+                    if ppm > 0:
+                        sqm = round(home.price / ppm)
+                        if 0 < sqm < 2000:
+                            home.sqm = sqm
+
+            self.homes.append(home)

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1618,6 +1618,70 @@ class TestParseMaxxhuren:
         assert len(results.homes) == 0
 
 
+class TestParseYourhouse:
+    def _card(self, status, heading, price, ppm="", kind="huur", city_slug="utrecht", slug="koekoekstraat/35-e"):
+        ppm_html = f'<span class="obj_pricepersquaremeter">{ppm}</span>' if ppm else ""
+        return f"""
+        <article class="object clearfix">
+            <a class="sys-property-link" href="/woningaanbod/{kind}/{city_slug}/{slug}?take=12">
+                <span class="object_status">{status}</span>
+            </a>
+            <div class="object_address">
+                <a class="sys-property-link object_header" href="/woningaanbod/{kind}/{city_slug}/{slug}?take=12">
+                    <h2>{heading}</h2>
+                </a>
+            </div>
+            <div class="object_data">
+                <span class="obj_price">{price}</span>
+                {ppm_html}
+            </div>
+        </article>
+        """
+
+    def test_basic_parsing(self, mock_response):
+        r = mock_response(self._card("Nieuw in verhuur", "Te huur: Koekoekstraat 35E, 3514CT Utrecht", "€ 946,- /mnd", ppm="€ 47,30/m2/mnd"))
+        results = HomeResults("yourhouse", r)
+        assert len(results.homes) == 1
+        assert results[0].agency == "yourhouse"
+        assert results[0].address == "Koekoekstraat 35E"
+        assert results[0].city == "Utrecht"
+        assert results[0].price == 946
+        assert results[0].sqm == 20  # derived from price / price-per-m²
+        assert results[0].url == "https://your-house.nl/woningaanbod/huur/utrecht/koekoekstraat/35-e"
+
+    def test_sqm_absent_when_no_price_per_sqm(self, mock_response):
+        r = mock_response(self._card("Nieuw in verhuur", "Te huur: Koekoekstraat 35E, 3514CT Utrecht", "€ 946,- /mnd"))
+        results = HomeResults("yourhouse", r)
+        assert len(results.homes) == 1
+        assert results[0].sqm == -1
+
+    def test_parses_thousands_separator(self, mock_response):
+        r = mock_response(self._card("Nieuw in verhuur", "Te huur: Albatrosstraat 32, 3582EX Utrecht", "€ 2.095,- /mnd"))
+        results = HomeResults("yourhouse", r)
+        assert len(results.homes) == 1
+        assert results[0].price == 2095
+
+    def test_filters_rented(self, mock_response):
+        r = mock_response(self._card("Verhuurd", "Verhuurd: Koekoekstraat 35E, 3514CT Utrecht", "€ 946,- /mnd"))
+        results = HomeResults("yourhouse", r)
+        assert len(results.homes) == 0
+
+    def test_filters_under_option(self, mock_response):
+        r = mock_response(self._card("Onder optie", "Onder optie: Van Weerden Poelmanlaan 60-1, 3527KP Utrecht", "€ 620,- /mnd"))
+        results = HomeResults("yourhouse", r)
+        assert len(results.homes) == 0
+
+    def test_filters_koop(self, mock_response):
+        r = mock_response(self._card("Nieuw", "Te koop: Pieter Nieuwlandstraat 86, 3514HL Utrecht", "€ 450.000,- k.k.", kind="koop"))
+        results = HomeResults("yourhouse", r)
+        assert len(results.homes) == 0
+
+    def test_filters_address_without_house_number(self, mock_response):
+        r = mock_response(self._card("Nieuw in verhuur", "Te huur: Nieuwbouwproject Centrum, 3514CT Utrecht", "€ 946,- /mnd"))
+        results = HomeResults("yourhouse", r)
+        assert len(results.homes) == 0
+
+
 class TestParseEasylease:
     def test_basic_parsing(self, mock_response):
         data = {


### PR DESCRIPTION
Adds a parser for [your-house.nl](https://your-house.nl/woningaanbod) (agency `yourhouse`).

## What it does
- New `parse_yourhouse()` parsing the server-rendered `article.object` cards: address/city from the `<h2>` heading, price from `.obj_price`.
- Scopes to rentals only (`/huur/` URLs) and keeps only `Te huur` listings, filtering out `Verhuurd`, `Onder optie`, and `koop`. Requires a house number in the address.
- Derives floor area from `price ÷ price-per-m²` (cards carry no direct surface area); verified exact against detail pages.
- Per-agency scraper service added to both compose files.

## Verification
- 100 parser tests pass; new `TestParseYourhouse` covers basic parsing, thousands separator, rented/under-option/koop/no-house-number filters, and sqm derivation.
- Listing URLs return HTTP 200; all parsed addresses contain house numbers.
- Live end-to-end run stored all 8 available listings with correct sizes; re-run confirmed dedup (no duplicates).

The DB target row is managed directly in the database, per convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)