### PR TITLE
Add Huurportaal scraper

### DIFF
--- a/docker/docker-compose-dev.yml
+++ b/docker/docker-compose-dev.yml
@@ -175,6 +175,12 @@ services:
     environment:
       - HESTIA_TARGET=hoekstra
 
+  hestia-scraper-huurportaal-dev:
+    <<: *scraper-dev-base
+    container_name: hestia-scraper-huurportaal-dev
+    environment:
+      - HESTIA_TARGET=huurportaal
+
   hestia-scraper-ikwilhuren-dev:
     container_name: hestia-scraper-ikwilhuren-dev
     healthcheck:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -175,6 +175,12 @@ services:
     environment:
       - HESTIA_TARGET=hoekstra
 
+  hestia-scraper-huurportaal:
+    <<: *scraper-base
+    container_name: hestia-scraper-huurportaal
+    environment:
+      - HESTIA_TARGET=huurportaal
+
   hestia-scraper-ikwilhuren:
     container_name: hestia-scraper-ikwilhuren
     healthcheck:

--- a/hestia/hestia_utils/parser.py
+++ b/hestia/hestia_utils/parser.py
@@ -147,6 +147,8 @@ class HomeResults:
             self.parse_beumer(raw)
         elif source == "nederwoon":
             self.parse_nederwoon(raw)
+        elif source == "huurportaal":
+            self.parse_huurportaal(raw)
         else:
             raise ValueError(f"Unknown source: {source}")
 
@@ -1078,6 +1080,71 @@ class HomeResults:
                             home.sqm = sqm_i
                     break
 
+            self.homes.append(home)
+
+    def parse_huurportaal(self, r: requests.models.Response):
+        # The listing page embeds a schema.org ItemList in a JSON-LD script,
+        # which is more stable than the rendered Next.js HTML.
+        soup = BeautifulSoup(r.content, "html.parser")
+
+        items = []
+        for script in soup.find_all("script", type="application/ld+json"):
+            try:
+                data = json.loads(script.string or "")
+            except (json.JSONDecodeError, TypeError):
+                continue
+            main_entity = data.get("mainEntity", {})
+            if main_entity.get("@type") == "ItemList":
+                items = main_entity.get("itemListElement", [])
+                break
+
+        seen: set[tuple[str, str]] = set()
+        for element in items:
+            item = element.get("item", {})
+            offer = item.get("offers", {})
+
+            # Only currently available listings
+            if not str(offer.get("availability", "")).endswith("InStock"):
+                continue
+
+            offered = offer.get("itemOffered", {})
+            address_info = offered.get("address", {})
+            street_address = address_info.get("streetAddress", "")
+            city = address_info.get("addressLocality", "")
+            url = item.get("url") or offer.get("url")
+            if not street_address or not city or not url:
+                continue
+
+            # streetAddress is "<street> <number>, <postcode> <city>, Netherlands";
+            # the first segment is the street and house number.
+            address = street_address.split(",")[0].strip()
+            if not re.search(r"\d", address):
+                continue
+
+            price = offer.get("price")
+            try:
+                price = int(float(price))
+            except (TypeError, ValueError):
+                continue
+
+            home = Home(agency="huurportaal")
+            home.address = address
+            home.city = city
+            home.url = url
+            home.price = price
+
+            floor_size = offered.get("floorSize", {})
+            try:
+                sqm = int(float(floor_size.get("value")))
+                if 0 < sqm < 2000:
+                    home.sqm = sqm
+            except (TypeError, ValueError):
+                pass
+
+            key = (home.address.lower(), home.city.lower())
+            if key in seen:
+                continue
+            seen.add(key)
             self.homes.append(home)
 
     def parse_maxxhuren(self, r: requests.models.Response):

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1570,6 +1570,50 @@ class TestParseNederwoon:
         assert results[0].price == 1200
 
 
+class TestParseHuurportaal:
+    def _page(self, items):
+        ld = {
+            "@context": "https://schema.org",
+            "@type": "SearchResultsPage",
+            "mainEntity": {"@type": "ItemList", "itemListElement": items},
+        }
+        return f'<html><head><script type="application/ld+json">{json.dumps(ld)}</script></head><body></body></html>'
+
+    def _item(self, street_address, locality, price, url, sqm=None, availability="https://schema.org/InStock"):
+        offered = {"@type": "Apartment", "address": {"@type": "PostalAddress", "streetAddress": street_address, "addressLocality": locality}}
+        if sqm is not None:
+            offered["floorSize"] = {"@type": "QuantitativeValue", "value": sqm}
+        return {"@type": "ListItem", "url": url, "item": {"@type": "RealEstateListing", "url": url,
+                "offers": {"@type": "Offer", "availability": availability, "price": price, "priceCurrency": "EUR", "itemOffered": offered}}}
+
+    def test_basic_parsing(self, mock_response):
+        page = self._page([self._item("Asingaborg 3, 1082 SC Amsterdam, Netherlands", "Amsterdam", 2500, "https://huurportaal.nl/en/listings/x-p1", sqm=71)])
+        results = HomeResults("huurportaal", mock_response(page))
+        assert len(results.homes) == 1
+        assert results[0].agency == "huurportaal"
+        assert results[0].address == "Asingaborg 3"
+        assert results[0].city == "Amsterdam"
+        assert results[0].price == 2500
+        assert results[0].sqm == 71
+        assert results[0].url == "https://huurportaal.nl/en/listings/x-p1"
+
+    def test_filters_unavailable(self, mock_response):
+        page = self._page([self._item("Teststraat 10, 1000 AA Amsterdam, Netherlands", "Amsterdam", 1500, "https://huurportaal.nl/en/listings/x-p2", availability="https://schema.org/SoldOut")])
+        results = HomeResults("huurportaal", mock_response(page))
+        assert len(results.homes) == 0
+
+    def test_filters_address_without_house_number(self, mock_response):
+        page = self._page([self._item("Venneperweg, 2152 MD Nieuw-Vennep, Netherlands", "Nieuw-Vennep", 825, "https://huurportaal.nl/en/listings/x-p3")])
+        results = HomeResults("huurportaal", mock_response(page))
+        assert len(results.homes) == 0
+
+    def test_dedupes_repeated_listing(self, mock_response):
+        item = self._item("Asingaborg 3, 1082 SC Amsterdam, Netherlands", "Amsterdam", 2500, "https://huurportaal.nl/en/listings/x-p1", sqm=71)
+        page = self._page([item, item])
+        results = HomeResults("huurportaal", mock_response(page))
+        assert len(results.homes) == 1
+
+
 class TestParseMaxxhuren:
     def test_basic_parsing(self, mock_response):
         html = """


### PR DESCRIPTION
Adds a parser for [huurportaal.nl](https://huurportaal.nl/en/for-rent?order=desc) (agency `huurportaal`).

## What it does
- huurportaal.nl is a Next.js (App Router/RSC) site with no callable backend API, but each listing page embeds a schema.org `ItemList` in a JSON-LD script. `parse_huurportaal()` parses that structured JSON rather than the rendered HTML — more stable and complete.
- Per listing it reads url, price (`offers.price`, int EUR), address (first segment of `streetAddress`), city (`addressLocality`), and size (`floorSize.value`).
- Keeps only `InStock` offers, requires a house number in the address (drops project/complex entries), and dedupes repeated listings within a page.
- Per-agency scraper service added to both compose files.

## Verification
- 98 parser tests pass; new `TestParseHuurportaal` covers basic parsing, unavailable filtering, no-house-number filtering, and dedup.
- Sample listing URLs return HTTP 200; all parsed addresses contain house numbers.
- Live end-to-end run stored 18 listings with correct sizes (21 minus 1 duplicate and 2 without house numbers); re-run confirmed dedup.

The DB target row is managed directly in the database, per convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)