### PR TITLE
Add Gruno Verhuur scraper

### DIFF
--- a/docker/docker-compose-dev.yml
+++ b/docker/docker-compose-dev.yml
@@ -79,6 +79,12 @@ services:
     environment:
       - HESTIA_TARGET=funda
 
+  hestia-scraper-grunoverhuur-dev:
+    <<: *scraper-dev-base
+    container_name: hestia-scraper-grunoverhuur-dev
+    environment:
+      - HESTIA_TARGET=grunoverhuur
+
   hestia-scraper-hexia-dewoningzoeker-dev:
     <<: *scraper-dev-base
     container_name: hestia-scraper-hexia-dewoningzoeker-dev

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -79,6 +79,12 @@ services:
     environment:
       - HESTIA_TARGET=funda
 
+  hestia-scraper-grunoverhuur:
+    <<: *scraper-base
+    container_name: hestia-scraper-grunoverhuur
+    environment:
+      - HESTIA_TARGET=grunoverhuur
+
   hestia-scraper-hexia-dewoningzoeker:
     <<: *scraper-base
     container_name: hestia-scraper-hexia-dewoningzoeker

--- a/hestia/hestia_utils/parser.py
+++ b/hestia/hestia_utils/parser.py
@@ -149,6 +149,8 @@ class HomeResults:
             self.parse_nederwoon(raw)
         elif source == "huurportaal":
             self.parse_huurportaal(raw)
+        elif source == "grunoverhuur":
+            self.parse_grunoverhuur(raw)
         else:
             raise ValueError(f"Unknown source: {source}")
 
@@ -1145,6 +1147,82 @@ class HomeResults:
             if key in seen:
                 continue
             seen.add(key)
+            self.homes.append(home)
+
+    def parse_grunoverhuur(self, r: requests.models.Response):
+        soup = BeautifulSoup(r.content, "html.parser")
+        base_url = "https://www.grunoverhuur.nl"
+
+        unavailable_keywords = [
+            "verhuurd",
+            "onder optie",
+            "onder voorbehoud",
+            "verkocht",
+            "rented",
+            "withdrawn",
+            "niet beschikbaar",
+            "gereserveerd",
+        ]
+
+        for card in soup.select("article.objectcontainer"):
+            obj = card.select_one("div.object")
+            obj_classes = " ".join(obj.get("class", [])).lower() if obj else ""
+
+            status_tag = card.select_one(".object_status")
+            status_text = status_tag.get_text(" ", strip=True).lower() if status_tag else ""
+            if any(kw in status_text for kw in unavailable_keywords) or "rented" in obj_classes:
+                continue
+
+            link = card.select_one("a.sys-property-link[href]") or card.select_one(".datacontainer a[href]")
+            if not link:
+                continue
+            url = parse.urljoin(base_url, str(link["href"]).split("?")[0])
+
+            # The address sits in ".obj_sub_address" ("<street> <nr>, <postcode> <city>");
+            # some cards omit it and carry the same string in the title behind a "Te huur:" prefix.
+            addr_tag = card.select_one(".obj_sub_address")
+            if addr_tag:
+                full_address = addr_tag.get_text(" ", strip=True)
+            else:
+                title_tag = card.select_one(".obj_address")
+                full_address = title_tag.get_text(" ", strip=True) if title_tag else ""
+                full_address = re.sub(r"(?i)^te\s+(?:huur|koop)\s*:\s*", "", full_address)
+
+            segments = [seg.strip() for seg in full_address.split(",") if seg.strip()]
+            if len(segments) < 2:
+                continue
+            address = " ".join(segments[0].split())
+            if not re.search(r"\d", address):
+                continue
+            # Strip the leading Dutch postcode (e.g. "9718CA" / "9718 CA") to get the city.
+            city = re.sub(r"^\s*\d{4}\s*[A-Za-z]{2}\s*", "", segments[1]).strip()
+            if not city:
+                continue
+
+            price_tag = card.select_one(".obj_price")
+            if not price_tag:
+                continue
+            amount_match = re.search(r"(\d[\d\.,]*)", price_tag.get_text(" ", strip=True))
+            if not amount_match:
+                continue
+            euros = amount_match.group(1).split(",")[0].replace(".", "")
+            if not euros.isdigit():
+                continue
+
+            home = Home(agency="grunoverhuur")
+            home.address = address
+            home.city = city
+            home.url = url
+            home.price = int(euros)
+
+            sqm_tag = card.select_one('.object_sqfeet span[title="Woonoppervlakte"]')
+            if sqm_tag:
+                sqm_match = re.search(r"(\d{1,4})", sqm_tag.get_text(" ", strip=True))
+                if sqm_match:
+                    sqm = int(sqm_match.group(1))
+                    if 0 < sqm < 2000:
+                        home.sqm = sqm
+
             self.homes.append(home)
 
     def parse_maxxhuren(self, r: requests.models.Response):

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1614,6 +1614,102 @@ class TestParseHuurportaal:
         assert len(results.homes) == 1
 
 
+class TestParseGrunoverhuur:
+    def _card(self, href, title, price, sub_address=None, sqm=None, status="Nieuw in verhuur", obj_class="object thumbnail new_forrent"):
+        status_html = f'<span class="object_status"><span>{status}</span></span>' if status else ""
+        sub_html = f'<span class="obj_sub_address">{sub_address}</span>' if sub_address else ""
+        sqm_html = ""
+        if sqm is not None:
+            sqm_html = f'<span class="object_label object_sqfeet"><span><span title="Woonoppervlakte">{sqm} m²</span></span></span>'
+        price_html = f'<span class="obj_price">{price}</span>' if price else ""
+        return f"""
+        <article class="col-xs-12 col-md-6 objectcontainer">
+            <div class="{obj_class}">
+                <div class="imagecontainer">
+                    <a class="sys-property-link" href="{href}" title="{title}"></a>
+                    {status_html}
+                </div>
+                <div class="datacontainer">
+                    <a href="{href}">
+                        <div class="object_data">
+                            <div class="obj_address_container">
+                                <h3 class="obj_address title">{title}</h3>
+                                {sub_html}
+                            </div>
+                            <span class="obj_type_price">{price_html}</span>
+                            <div class="object_data_labels">{sqm_html}</div>
+                        </div>
+                    </a>
+                </div>
+            </div>
+        </article>
+        """
+
+    def _page(self, *cards):
+        return f"<html><body><div class='object_list'>{''.join(cards)}</div></body></html>"
+
+    def test_basic_parsing(self, mock_response):
+        html = self._page(self._card(
+            "/woningaanbod/huur/groningen/westersingel/19-a?take=10",
+            "Te huur: 2 kamers aan de Westersingel!",
+            "€ 1.135,- /mnd",
+            sub_address="Smaragdstraat 23, 9743KS Groningen",
+            sqm=27,
+        ))
+        results = HomeResults("grunoverhuur", mock_response(html))
+        assert len(results.homes) == 1
+        assert results[0].agency == "grunoverhuur"
+        assert results[0].address == "Smaragdstraat 23"
+        assert results[0].city == "Groningen"
+        assert results[0].price == 1135
+        assert results[0].sqm == 27
+        assert results[0].url == "https://www.grunoverhuur.nl/woningaanbod/huur/groningen/westersingel/19-a"
+
+    def test_falls_back_to_title_address(self, mock_response):
+        # Some cards omit the sub-address and carry it in the title behind a "Te huur:" prefix.
+        html = self._page(self._card(
+            "/woningaanbod/huur/groningen/siriusstraat/51?take=10",
+            "Te huur: Siriusstraat 51, 9742KV Groningen",
+            "€ 740,- /mnd",
+            sqm=16,
+        ))
+        results = HomeResults("grunoverhuur", mock_response(html))
+        assert len(results.homes) == 1
+        assert results[0].address == "Siriusstraat 51"
+        assert results[0].city == "Groningen"
+
+    def test_filters_unavailable_status(self, mock_response):
+        html = self._page(self._card(
+            "/woningaanbod/huur/groningen/teststraat/10?take=10",
+            "Te huur: Teststraat 10",
+            "€ 1.000,- /mnd",
+            sub_address="Teststraat 10, 1000 AA Amsterdam",
+            status="Verhuurd",
+        ))
+        results = HomeResults("grunoverhuur", mock_response(html))
+        assert len(results.homes) == 0
+
+    def test_filters_address_without_house_number(self, mock_response):
+        html = self._page(self._card(
+            "/woningaanbod/huur/groningen/nieuwbouwproject?take=10",
+            "Te huur: Nieuwbouwproject Centrum",
+            "€ 950,- /mnd",
+            sub_address="Nieuwbouwproject Centrum, 9700 AA Groningen",
+        ))
+        results = HomeResults("grunoverhuur", mock_response(html))
+        assert len(results.homes) == 0
+
+    def test_skips_listing_without_price(self, mock_response):
+        html = self._page(self._card(
+            "/woningaanbod/huur/groningen/prijsloos/1?take=10",
+            "Te huur: Prijsloos 1",
+            "",
+            sub_address="Prijsloos 1, 9700 AA Groningen",
+        ))
+        results = HomeResults("grunoverhuur", mock_response(html))
+        assert len(results.homes) == 0
+
+
 class TestParseMaxxhuren:
     def test_basic_parsing(self, mock_response):
         html = """


### PR DESCRIPTION
Adds a scraper for [Gruno Verhuur](https://www.grunoverhuur.nl/woningaanbod/huur).

The site is server-rendered HTML with no JSON/API endpoint, so the parser uses BeautifulSoup over the `article.objectcontainer` listing cards (following the `parse_maxxhuren` pattern). It:
- filters unavailable listings (`verhuurd`, `onder optie`, etc.),
- reads the address from `.obj_sub_address` (falling back to the title for cards that omit it),
- strips the Dutch postcode to get the city, skips addresses without a house number,
- parses the price to a plain int and grabs floor area.

Includes:
- `parse_grunoverhuur` + dispatch branch in `parser.py`
- `hestia-scraper-grunoverhuur(-dev)` services in both compose files
- `TestParseGrunoverhuur` (5 cases)

## Verification
- Full parser suite: 103 passed
- Verified against live HTML (10 homes on page 1) using the exact stored target config (HTTP 200)
- Confirmed parsed listing URLs return HTTP 200
- Ran a real dev scrape: 10 homes inserted correctly

## Prod target row
Run against the prod DB after merge:
```sql
INSERT INTO hestia.targets (agency, queryurl, method, user_info, post_data, headers, enabled)
VALUES ('grunoverhuur', 'https://www.grunoverhuur.nl/woningaanbod/huur?moveunavailablelistingstothebottom=true', 'GET', '{"agency": "Gruno Verhuur", "website": "grunoverhuur.nl"}'::jsonb, '{}'::jsonb, '{"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36"}'::json, true);
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)