### PR TITLE
Add LIV Residential scraper

### DIFF
--- a/docker/docker-compose-dev.yml
+++ b/docker/docker-compose-dev.yml
@@ -202,6 +202,12 @@ services:
     environment:
       - HESTIA_TARGET=krk
 
+  hestia-scraper-livresidential-dev:
+    <<: *scraper-dev-base
+    container_name: hestia-scraper-livresidential-dev
+    environment:
+      - HESTIA_TARGET=livresidential
+
   hestia-scraper-maxxhuren-dev:
     <<: *scraper-dev-base
     container_name: hestia-scraper-maxxhuren-dev

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -202,6 +202,12 @@ services:
     environment:
       - HESTIA_TARGET=krk
 
+  hestia-scraper-livresidential:
+    <<: *scraper-base
+    container_name: hestia-scraper-livresidential
+    environment:
+      - HESTIA_TARGET=livresidential
+
   hestia-scraper-maxxhuren:
     <<: *scraper-base
     container_name: hestia-scraper-maxxhuren

--- a/hestia/hestia_utils/parser.py
+++ b/hestia/hestia_utils/parser.py
@@ -147,6 +147,8 @@ class HomeResults:
             self.parse_beumer(raw)
         elif source == "nederwoon":
             self.parse_nederwoon(raw)
+        elif source == "livresidential":
+            self.parse_livresidential(raw)
         else:
             raise ValueError(f"Unknown source: {source}")
 
@@ -1138,6 +1140,61 @@ class HomeResults:
                             home.sqm = sqm
             except Exception:
                 pass
+            self.homes.append(home)
+
+    def parse_livresidential(self, r: requests.models.Response):
+        # Listings are server-rendered; only available homes appear on the
+        # overview page, so there is no rented status to filter out.
+        soup = BeautifulSoup(r.content, "html.parser")
+
+        seen: set[tuple[str, str]] = set()
+        for card in soup.find_all("a", href=re.compile(r"/huurwoningen/[^/]+/[^/]+/[^/]+$")):
+            url = card.get("href")
+            address_tag = card.find("h3")
+            if not url or not address_tag:
+                continue
+
+            # The <h3> reads "<street> <number> <postcode> <city>"; drop the
+            # postcode and everything after it to keep just street + number.
+            full_address = " ".join(address_tag.get_text(" ", strip=True).split())
+            address = re.sub(r"\s*\d{4}\s?[A-Z]{2}\b.*$", "", full_address).strip()
+            if not address or not re.search(r"\d", address):
+                continue
+
+            # The <p> under the address holds "<postcode> <city>".
+            city = ""
+            for p in card.find_all("p"):
+                m = re.match(r"^\d{4}\s?[A-Z]{2}\s+(.+)$", p.get_text(" ", strip=True))
+                if m:
+                    city = m.group(1).strip()
+                    break
+
+            price = None
+            for p in card.find_all("p"):
+                if "€" in p.get_text():
+                    m = re.search(r"(\d[\d.]*)", p.get_text())
+                    if m:
+                        price = int(m.group(1).replace(".", ""))
+                    break
+            if not city or price is None:
+                continue
+
+            home = Home(agency="livresidential")
+            home.address = address
+            home.city = city
+            home.url = parse.urljoin("https://livresidential.nl", str(url))
+            home.price = price
+
+            m = re.search(r"(\d{1,4})\s*m2", card.get_text())
+            if m:
+                sqm = int(m.group(1))
+                if 0 < sqm < 2000:
+                    home.sqm = sqm
+
+            key = (home.address.lower(), home.city.lower())
+            if key in seen:
+                continue
+            seen.add(key)
             self.homes.append(home)
 
     def parse_hoekstra(self, r: requests.models.Response):

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1570,6 +1570,63 @@ class TestParseNederwoon:
         assert results[0].price == 1200
 
 
+class TestParseLivresidential:
+    def _card(self, path, full_address, postcode_city, price, sqm=None):
+        sqm_html = f'<div class="ml-2 text-c-500">{sqm} m2</div>' if sqm is not None else ""
+        return f'''
+        <a class="flex flex-col" href="https://livresidential.nl{path}">
+            <div class="flex-1 bg-white p-5">
+                <h3 class="font-semibold text-c-800">{full_address}</h3>
+                <p class="text-base text-c-500">{postcode_city}</p>
+                <p class="mt-3 text-base font-medium text-c-700">{price}</p>
+            </div>
+            <div class="flex">{sqm_html}</div>
+        </a>'''
+
+    def _page(self, cards):
+        return f'<html><body><div class="ais-Hits">{"".join(cards)}</div></body></html>'
+
+    def test_basic_parsing(self, mock_response):
+        page = self._page([self._card(
+            "/huurwoningen/amsterdam/amsterdam/karspeldreef-4-c39-1101cj-amsterdam",
+            "Karspeldreef 4 C39 1101CJ Amsterdam", "1101CJ Amsterdam",
+            "€ 1.358 per maand (excl.)", sqm=58)])
+        results = HomeResults("livresidential", mock_response(page))
+        assert len(results.homes) == 1
+        assert results[0].agency == "livresidential"
+        assert results[0].address == "Karspeldreef 4 C39"
+        assert results[0].city == "Amsterdam"
+        assert results[0].price == 1358
+        assert results[0].sqm == 58
+        assert results[0].url == "https://livresidential.nl/huurwoningen/amsterdam/amsterdam/karspeldreef-4-c39-1101cj-amsterdam"
+
+    def test_filters_address_without_house_number(self, mock_response):
+        page = self._page([self._card(
+            "/huurwoningen/utrecht/utrecht/venneperweg-2152md-utrecht",
+            "Venneperweg 2152MD Utrecht", "2152MD Utrecht",
+            "€ 825 per maand (excl.)")])
+        results = HomeResults("livresidential", mock_response(page))
+        assert len(results.homes) == 0
+
+    def test_dedupes_repeated_listing(self, mock_response):
+        card = self._card(
+            "/huurwoningen/amsterdam/amsterdam/karspeldreef-4-c39-1101cj-amsterdam",
+            "Karspeldreef 4 C39 1101CJ Amsterdam", "1101CJ Amsterdam",
+            "€ 1.358 per maand (excl.)", sqm=58)
+        results = HomeResults("livresidential", mock_response(self._page([card, card])))
+        assert len(results.homes) == 1
+
+    def test_parses_without_sqm(self, mock_response):
+        page = self._page([self._card(
+            "/huurwoningen/rotterdam/rotterdam/spoorsingel-70-a-3033gp-rotterdam",
+            "Spoorsingel 70 A 3033GP Rotterdam", "3033GP Rotterdam",
+            "€ 1.295 per maand (excl.)")])
+        results = HomeResults("livresidential", mock_response(page))
+        assert len(results.homes) == 1
+        assert results[0].address == "Spoorsingel 70 A"
+        assert results[0].sqm == -1
+
+
 class TestParseMaxxhuren:
     def test_basic_parsing(self, mock_response):
         html = """


### PR DESCRIPTION
Adds a scraper for [livresidential.nl/huurwoningen](https://livresidential.nl/huurwoningen).

## Notes
- No JSON/API or JSON-LD exposed (the `ais-Hits` Algolia markup is present but no credentials), so listings are parsed from the server-rendered HTML.
- Only available homes appear on the overview page, so there is no rented status to filter.
- Extracts street + house number (postcode/city stripped), city, price (€ → int), and sqm; filters addresses without a house number and dedupes repeats.

## Verification
- All 20 live listings parse cleanly; every address contains a house number.
- Sampled detail URLs return HTTP 200.
- Manual scrape via the dev container stored all 20 homes.
- Parser test suite: 98 passed.

The DB target row must be added to prod separately (managed outside the repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)