### PR TITLE
Add At Home Vastgoed scraper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ hestia/hestia_utils/athome_scraper.py
 tests/test_ikwilhuren_scraper.py
 tests/test_pararius_scraper.py
 requirements-private.txt
+sync-secret-parsers.sh
 # Hestia specific files
 error.log
 hestia.log

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ AGENTS.md
 misc/maintenance.py
 hestia/hestia_utils/pararius_scraper.py
 hestia/hestia_utils/ikwilhuren_scraper.py
+hestia/hestia_utils/athome_scraper.py
 tests/test_ikwilhuren_scraper.py
 tests/test_pararius_scraper.py
 requirements-private.txt

--- a/docker/docker-compose-dev.yml
+++ b/docker/docker-compose-dev.yml
@@ -49,6 +49,12 @@ services:
     environment:
       - HESTIA_TARGET=alliantie
 
+  hestia-scraper-athome-dev:
+    <<: *scraper-dev-base
+    container_name: hestia-scraper-athome-dev
+    environment:
+      - HESTIA_TARGET=athome
+
   hestia-scraper-atta-dev:
     <<: *scraper-dev-base
     container_name: hestia-scraper-atta-dev

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -49,6 +49,12 @@ services:
     environment:
       - HESTIA_TARGET=alliantie
 
+  hestia-scraper-athome:
+    <<: *scraper-base
+    container_name: hestia-scraper-athome
+    environment:
+      - HESTIA_TARGET=athome
+
   hestia-scraper-atta:
     <<: *scraper-base
     container_name: hestia-scraper-atta

--- a/hestia/hestia_utils/parser.py
+++ b/hestia/hestia_utils/parser.py
@@ -155,6 +155,8 @@ class HomeResults:
             self.parse_grunoverhuur(raw)
         elif source == "yourhouse":
             self.parse_yourhouse(raw)
+        elif source == "athome":
+            self.parse_athome(raw)
         else:
             raise ValueError(f"Unknown source: {source}")
 
@@ -1226,6 +1228,79 @@ class HomeResults:
                     sqm = int(sqm_match.group(1))
                     if 0 < sqm < 2000:
                         home.sqm = sqm
+
+            self.homes.append(home)
+
+    def parse_athome(self, r: requests.models.Response):
+        base_url = "https://www.athomevastgoed.nl"
+
+        # Listings are server-rendered into a Vuex store commit as a Laravel
+        # paginator object: store.commit('SET_PROPERTIES_COLLECTION', {...}).
+        html = r.content.decode("utf-8", "replace")
+        marker = "SET_PROPERTIES_COLLECTION',"
+        idx = html.find(marker)
+        if idx == -1:
+            return
+        brace = html.find("{", idx + len(marker))
+        if brace == -1:
+            return
+        data = chompjs.parse_js_object(html[brace:])
+
+        unavailable_keywords = [
+            "verhuurd",
+            "onder optie",
+            "onder voorbehoud",
+            "verkocht",
+            "rented",
+            "withdrawn",
+            "niet beschikbaar",
+            "gereserveerd",
+        ]
+
+        for listing in data.get("data", []):
+            status = listing.get("status") or {}
+            status_lang = status.get("value_lang") or {}
+            status_text = " ".join(
+                str(v) for v in [status.get("value"), status_lang.get("en"), status_lang.get("nl")] if v
+            ).lower()
+            if any(kw in status_text for kw in unavailable_keywords):
+                continue
+
+            street = (listing.get("street") or "").strip()
+            if not street:
+                continue
+
+            location = listing.get("location") or {}
+            city = (location.get("name") or "").strip()
+            if not city:
+                continue
+
+            url = (listing.get("url") or "").strip()
+            if not url:
+                continue
+
+            # Prices look like "2850,00" (comma decimals, no thousands separator).
+            euros = (listing.get("ah_price") or "").split(",")[0].replace(".", "")
+            if not euros.isdigit() or int(euros) <= 0:
+                continue
+            price = int(euros)
+
+            # At Home only lists the street, never a house number. Mirror the
+            # Pararius handling and append the price so the address stays a
+            # usable unique identifier.
+            address = street
+            if not re.search(r"\d", address):
+                address += f" [€{price}]"
+
+            home = Home(agency="athome")
+            home.address = address
+            home.city = city
+            home.url = parse.urljoin(base_url, url)
+            home.price = price
+
+            area = listing.get("area")
+            if isinstance(area, int) and 0 < area < 2000:
+                home.sqm = area
 
             self.homes.append(home)
 

--- a/hestia/scraper.py
+++ b/hestia/scraper.py
@@ -25,6 +25,12 @@ try:
 except ImportError:
     HAS_IKWILHUREN_SCRAPER = False
 
+try:
+    from hestia_utils.athome_scraper import scrape_athome
+    HAS_ATHOME_SCRAPER = True
+except ImportError:
+    HAS_ATHOME_SCRAPER = False
+
 import hestia_utils.db as db
 import hestia_utils.meta as meta
 import hestia_utils.secrets as secrets
@@ -307,6 +313,22 @@ async def scrape_site(target: dict) -> None:
             for home in db.fetch_all("SELECT address, city FROM hestia.homes WHERE date_added > now() - interval '180 day'")
         ]
         for home in scrape_pararius(target):
+            if home not in prev_homes:
+                new_homes.append(home)
+        for home in new_homes:
+            db.add_home(home.url, home.address, home.city, home.price, home.agency, datetime.now(timezone.utc).replace(tzinfo=None).isoformat(), home.sqm)
+        await broadcast(new_homes)
+
+    elif target["agency"] == "athome":
+        if not HAS_ATHOME_SCRAPER:
+            logger.warning("At Home scraper module not found, skipping")
+            return
+        new_homes = []
+        prev_homes = [
+            Home(home["address"], home["city"])
+            for home in db.fetch_all("SELECT address, city FROM hestia.homes WHERE date_added > now() - interval '180 day'")
+        ]
+        for home in scrape_athome(target):
             if home not in prev_homes:
                 new_homes.append(home)
         for home in new_homes:

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1877,6 +1877,69 @@ class TestParseYourhouse:
         assert len(results.homes) == 0
 
 
+class TestParseAthome:
+    def _listing(self, street="Honingerdijk", city="Rotterdam", price="2850,00",
+                 status="Actief", status_en="Active", area=141,
+                 url="https://www.athomevastgoed.nl/woningaanbod/huren-appartement-rotterdam-honingerdijk-te-huur-5462"):
+        return {
+            "street": street,
+            "ah_price": price,
+            "area": area,
+            "url": url,
+            "location": {"name": city},
+            "status": {"value": status, "value_lang": {"en": status_en, "nl": status}},
+        }
+
+    def _page(self, listings):
+        payload = {"current_page": 1, "data": listings, "last_page": 1, "total": len(listings)}
+        return "<html><body><script>store.commit('SET_PROPERTIES_COLLECTION', " + json.dumps(payload) + ");</script></body></html>"
+
+    def test_basic_parsing(self, mock_response):
+        r = mock_response(self._page([self._listing()]))
+        results = HomeResults("athome", r)
+        assert len(results.homes) == 1
+        assert results[0].agency == "athome"
+        # No house number is ever listed; price is appended for uniqueness.
+        assert results[0].address == "Honingerdijk [€2850]"
+        assert results[0].city == "Rotterdam"
+        assert results[0].price == 2850
+        assert results[0].sqm == 141
+        assert results[0].url == "https://www.athomevastgoed.nl/woningaanbod/huren-appartement-rotterdam-honingerdijk-te-huur-5462"
+
+    def test_parses_decimal_price(self, mock_response):
+        r = mock_response(self._page([self._listing(street="Sternstraat", price="807,50")]))
+        results = HomeResults("athome", r)
+        assert len(results.homes) == 1
+        assert results[0].price == 807
+        assert results[0].address == "Sternstraat [€807]"
+
+    def test_filters_rented(self, mock_response):
+        r = mock_response(self._page([self._listing(status="Verhuurd", status_en="Rented")]))
+        results = HomeResults("athome", r)
+        assert len(results.homes) == 0
+
+    def test_skips_missing_street(self, mock_response):
+        r = mock_response(self._page([self._listing(street="")]))
+        results = HomeResults("athome", r)
+        assert len(results.homes) == 0
+
+    def test_skips_zero_price(self, mock_response):
+        r = mock_response(self._page([self._listing(price="0,00")]))
+        results = HomeResults("athome", r)
+        assert len(results.homes) == 0
+
+    def test_resolves_relative_url(self, mock_response):
+        r = mock_response(self._page([self._listing(url="/woningaanbod/huren-studio-rotterdam-foo")]))
+        results = HomeResults("athome", r)
+        assert len(results.homes) == 1
+        assert results[0].url == "https://www.athomevastgoed.nl/woningaanbod/huren-studio-rotterdam-foo"
+
+    def test_no_blob_returns_empty(self, mock_response):
+        r = mock_response("<html><body>no listings here</body></html>")
+        results = HomeResults("athome", r)
+        assert len(results.homes) == 0
+
+
 class TestParseEasylease:
     def test_basic_parsing(self, mock_response):
         data = {


### PR DESCRIPTION
Adds a scraper for [athomevastgoed.nl/woningaanbod](https://www.athomevastgoed.nl/woningaanbod).

## Notes
- Parsing lives in `parse_athome` in `parser.py` and is covered by tests. Listings are read from the JSON the site renders into its page state.
- The site never lists a house number (only the street), so — like some other agencies — the price is appended to the address (`Honingerdijk [€2850]`) to keep it a usable unique identifier.
- Filters out unavailable statuses (verhuurd, onder optie, etc.).

## Testing
- New `TestParseAthome` tests pass; full suite green (389 passed).
- Verified live scrape returns the expected listings and detail URLs return HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)