### PR TITLE
Make scraper zero-results alert window configurable per target

### DIFF
--- a/hestia/hestia_utils/db.py
+++ b/hestia/hestia_utils/db.py
@@ -198,23 +198,27 @@ def cleanup_error_rollups(retention_days: int = 30) -> None:
     )
 
 
-def get_enabled_targets_without_recent_homes(days: int = 7) -> list[RealDictRow]:
+def get_enabled_targets_without_recent_homes(default_days: int = 7) -> list[RealDictRow]:
+    # Each target may override the alert window via alert_threshold_days;
+    # NULL falls back to default_days. The interval references the per-row
+    # value so every target is evaluated against its own threshold.
     return fetch_all(
         """
         SELECT
             t.id,
             t.agency,
+            COALESCE(t.alert_threshold_days, %s)::int AS threshold_days,
             COUNT(h.url) AS homes_count
         FROM hestia.targets t
         LEFT JOIN hestia.homes h
             ON h.agency = t.agency
-           AND h.date_added >= now() - (%s::int * interval '1 day')
+           AND h.date_added >= now() - (COALESCE(t.alert_threshold_days, %s)::int * interval '1 day')
         WHERE t.enabled = true
-        GROUP BY t.id, t.agency
+        GROUP BY t.id, t.agency, threshold_days
         HAVING COUNT(h.url) = 0
         ORDER BY t.id
         """,
-        [days],
+        [default_days, default_days],
     )
 
 def set_filter_minprice(telegram_chat: Chat, min_price: int) -> None:

--- a/hestia/scraper.py
+++ b/hestia/scraper.py
@@ -89,13 +89,13 @@ def _build_daily_error_digest() -> str:
 
 
 def _build_zero_results_digest() -> str:
-    rows = db.get_enabled_targets_without_recent_homes(days=7)
+    rows = db.get_enabled_targets_without_recent_homes(default_days=7)
     if not rows:
         return ""
 
-    message = "\n\nEnabled targets with 0 listings in the past 7 days:"
+    message = "\n\nEnabled targets with 0 listings within their alert window:"
     for row in rows:
-        message += f"\n- {row['agency']} ({row['id']})"
+        message += f"\n- {row['agency']} ({row['id']}): 0 in past {row['threshold_days']} days"
     return message
 
 

--- a/misc/hestia.ddl
+++ b/misc/hestia.ddl
@@ -147,7 +147,8 @@ CREATE TABLE hestia.targets (
   user_info jsonb NOT NULL,
   post_data jsonb DEFAULT '{}'::json NOT NULL,
   headers json DEFAULT '{}'::json NOT NULL,
-  enabled bool DEFAULT false NOT NULL
+  enabled bool DEFAULT false NOT NULL,
+  alert_threshold_days int4
 );
 
 


### PR DESCRIPTION
## What

The scraper alerts when an enabled target has 0 listings within a hardcoded 7-day window. This makes the window configurable per target via a new nullable `hestia.targets.alert_threshold_days` column.

- `NULL` → falls back to the default 7 (existing behavior unchanged).
- Set a smaller value (e.g. `1`) for targets that should alert sooner.
- Set a large value (e.g. `9999`) to effectively silence a noisy/slow target.

The threshold is pushed into the per-target join so each target is evaluated against its own window, and the digest now reports each target's window (`0 in past N days`).

## Changes

- `db.py` — `get_enabled_targets_without_recent_homes` uses `COALESCE(t.alert_threshold_days, default_days)` in the join interval and returns `threshold_days`.
- `scraper.py` — digest renders the per-target window.
- `misc/hestia.ddl` — adds the column to the schema.

The column is set manually in the DB; nothing is wired around editing it.

## DB migration

```sql
ALTER TABLE hestia.targets ADD COLUMN alert_threshold_days int4;
```

Nullable, no default → metadata-only change, existing rows read back `NULL` (default 7). Applied to the dev DB.

## Testing

- Full e2e in the dev env against the live dev DB, exercising the real `_build_zero_results_digest()` over a 5-target matrix (NULL/default, recent-within-window, short override, long override/suppress, disabled). All cases behaved as expected; output rendered the correct per-target windows.
- Existing suite: 248 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)