### PR TITLE
Fix scraper cron entries stacking on container restart

### DIFF
--- a/docker/entrypoint-scraper.sh
+++ b/docker/entrypoint-scraper.sh
@@ -3,5 +3,8 @@ DELAY=$(shuf -i 0-300 -n 1)
 SCHEDULE="${HESTIA_CRON_SCHEDULE:-*/5 * * * *}"
 echo "[$(date -u '+%Y-%m-%d %H:%M:%S UTC')] agency=${HESTIA_TARGET:-maintenance} delay=${DELAY}s schedule='${SCHEDULE}'"
 printenv | sed 's/=\(.*\)/="\1"/' > /etc/environment
-echo "${SCHEDULE} root . /etc/environment; sleep $DELAY && /usr/local/bin/python3 /scraper/hestia/scraper.py > /proc/1/fd/1 2>/proc/1/fd/2" >> /etc/crontab
+# Overwrite a dedicated cron.d file (not >> /etc/crontab) so restarts, which re-run
+# this entrypoint on the same writable layer, can't stack duplicate scrape entries.
+echo "${SCHEDULE} root . /etc/environment; sleep $DELAY && /usr/local/bin/python3 /scraper/hestia/scraper.py > /proc/1/fd/1 2>/proc/1/fd/2" > /etc/cron.d/hestia
+chmod 0644 /etc/cron.d/hestia
 exec cron -f


### PR DESCRIPTION
## Problem

Multiple scrapes of the same target were appearing in the logs within a single 5-minute window.

`entrypoint-scraper.sh` **appended** the scrape job to `/etc/crontab` with `>>`. The scraper containers run with `restart: unless-stopped`, and a Docker *restart* (crash auto-restart, daemon reboot, or `docker restart`) re-runs the entrypoint on the same writable layer — it does not recreate the filesystem. So each restart appended another cron line to the already-populated `/etc/crontab`, each with a freshly randomized `DELAY` (`shuf -i 0-300`).

After N restarts there were N cron entries for the same target, firing at N different offsets within each schedule window → multiple scrapes of the same target within 5 minutes at irregular spacing.

## Fix

Write the cron job to a dedicated `/etc/cron.d/hestia` file with `>` (overwrite) instead of appending to `/etc/crontab`. Overwriting makes the entrypoint idempotent, so restarts can no longer stack duplicate entries. `/etc/cron.d` uses the same format including the `root` user field already present in the line.

## Note

Already-running containers will keep their stale stacked `/etc/crontab` entries until recreated (`docker compose up -d --force-recreate`), since restarting alone reuses the old writable layer.