### PR TITLE
Add Interhouse scraper and surface Funda query errors

### DIFF
--- a/docker/docker-compose-dev.yml
+++ b/docker/docker-compose-dev.yml
@@ -214,6 +214,12 @@ services:
       - HESTIA_CRON_SCHEDULE=*/5 6-22 * * *
       - TZ=Europe/Amsterdam
 
+  hestia-scraper-interhouse-dev:
+    <<: *scraper-dev-base
+    container_name: hestia-scraper-interhouse-dev
+    environment:
+      - HESTIA_TARGET=interhouse
+
   hestia-scraper-krk-dev:
     <<: *scraper-dev-base
     container_name: hestia-scraper-krk-dev

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -214,6 +214,12 @@ services:
       - HESTIA_CRON_SCHEDULE=*/5 6-22 * * *
       - TZ=Europe/Amsterdam
 
+  hestia-scraper-interhouse:
+    <<: *scraper-base
+    container_name: hestia-scraper-interhouse
+    environment:
+      - HESTIA_TARGET=interhouse
+
   hestia-scraper-krk:
     <<: *scraper-base
     container_name: hestia-scraper-krk

--- a/hestia/hestia_utils/parser.py
+++ b/hestia/hestia_utils/parser.py
@@ -157,6 +157,8 @@ class HomeResults:
             self.parse_yourhouse(raw)
         elif source == "athome":
             self.parse_athome(raw)
+        elif source == "interhouse":
+            self.parse_interhouse(raw)
         else:
             raise ValueError(f"Unknown source: {source}")
 
@@ -406,8 +408,17 @@ class HomeResults:
             self.homes.append(home)
             
     def parse_funda(self, r: requests.models.Response):
-        results = json.loads(r.content)["responses"][0]["hits"]["hits"]
-        
+        response = json.loads(r.content)["responses"][0]
+        # Funda's Elasticsearch _msearch endpoint returns HTTP 200 even when the
+        # individual query fails: the failing sub-response carries an `error`
+        # object and a non-200 `status` instead of `hits`. Surface that instead
+        # of a bare KeyError: 'hits' so the real cause is visible in the alert.
+        if "hits" not in response:
+            status = response.get("status")
+            error = response.get("error", response)
+            raise ValueError(f"Funda returned no hits (status={status}): {json.dumps(error)[:1000]}")
+        results = response["hits"]["hits"]
+
         for res in results:
             # Some listings don't have house numbers, so skip
             if "house_number" not in res["_source"]["address"].keys():
@@ -1301,6 +1312,72 @@ class HomeResults:
             area = listing.get("area")
             if isinstance(area, int) and 0 < area < 2000:
                 home.sqm = area
+
+            self.homes.append(home)
+
+    def parse_interhouse(self, r: requests.models.Response):
+        soup = BeautifulSoup(r.content, "html.parser")
+
+        unavailable_keywords = [
+            "verhuurd",
+            "onder optie",
+            "onder voorbehoud",
+            "verkocht",
+            "rented",
+            "withdrawn",
+            "niet beschikbaar",
+            "gereserveerd",
+        ]
+
+        for card in soup.select("a.c-result-item"):
+            url = card.get("href")
+            # The feed mixes in for-sale ("koop") listings with otherwise
+            # identical markup, so restrict to rentals by their URL path.
+            if not url or "/vastgoed/huur/" not in url:
+                continue
+
+            # Rented/under-option listings still show up; their status is only
+            # reflected in the availability label inside the card text.
+            card_text = card.get_text(" ", strip=True).lower()
+            if any(keyword in card_text for keyword in unavailable_keywords):
+                continue
+
+            address_tag = card.select_one(".c-result-item__title-address")
+            city_tag = card.select_one(".c-result-item__location-label")
+            price_tag = card.select_one(".c-result-item__price")
+            if not address_tag or not city_tag or not price_tag:
+                continue
+
+            # Price reads like "€ 2.750 p/mnd Exclusief voorzieningen"; only the
+            # amount before "p/mnd" is the monthly rent.
+            price_text = price_tag.get_text(" ", strip=True).split("p/mnd")[0]
+            price_digits = re.sub(r"\D", "", price_text)
+            if not price_digits:
+                continue
+            price = int(price_digits)
+
+            # Interhouse only lists the street, never a house number. Mirror the
+            # At Home / Pararius handling and append the price so the address
+            # stays a usable unique identifier.
+            address = " ".join(address_tag.get_text(" ", strip=True).split())
+            if not re.search(r"\d", address):
+                address += f" [€{price}]"
+
+            home = Home(agency="interhouse")
+            home.address = address
+            home.city = city_tag.get_text(" ", strip=True)
+            home.url = url
+            home.price = price
+
+            data_table = card.select_one(".c-result-item__data-table")
+            if data_table:
+                # The living area shows as "Ca. 115 m²" (the "²" is a <sup>, so
+                # the text renders as "115 m 2").
+                m = re.search(r"(\d{1,4})\s*m\s*[²2]", data_table.get_text(" ", strip=True))
+                if m:
+                    sqm = int(m.group(1))
+                    if 0 < sqm < 2000:
+                        home.sqm = sqm
 
             self.homes.append(home)
 

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -657,6 +657,17 @@ class TestParseFunda:
         assert len(results.homes) == 1
         assert results[0].sqm == -1
 
+    def test_error_response_surfaces_cause(self, mock_response):
+        # Funda's _msearch returns HTTP 200 with a per-query error instead of
+        # `hits`; the parser should raise a descriptive error, not KeyError.
+        data = {"responses": [{
+            "error": {"type": "search_phase_execution_exception", "reason": "all shards failed"},
+            "status": 400,
+        }]}
+        r = mock_response(data)
+        with pytest.raises(ValueError, match="Funda returned no hits"):
+            HomeResults("funda", r)
+
 
 class TestParseRebo:
     def test_basic_parsing(self, mock_response):
@@ -1937,6 +1948,82 @@ class TestParseAthome:
     def test_no_blob_returns_empty(self, mock_response):
         r = mock_response("<html><body>no listings here</body></html>")
         results = HomeResults("athome", r)
+        assert len(results.homes) == 0
+
+
+class TestParseInterhouse:
+    def _card(self, address="Westerdok", city="Amsterdam",
+              url="https://interhouse.nl/vastgoed/huur/amsterdam/appartement/westerdok/",
+              type_label="Appartement Te huur", price="€ 2.750 p/mnd Exclusief voorzieningen",
+              availability="Beschikbaar", area="Ca. 115 m<sup>2</sup>"):
+        return f"""
+        <a href="{url}" class="c-result-item building-result">
+            <div class="c-result-item__content">
+                <h3 class="c-result-item__title">
+                    <span class="c-result-item__title-type">{type_label}</span>
+                    <span class="c-result-item__title-address">{address}</span>
+                </h3>
+                <p class="c-result-item__location-label">{city}</p>
+                <div class="c-result-item__data-table">
+                    <div class="c-result-item__data-table-item">{availability}</div>
+                    <div class="c-result-item__data-table-item">{area}</div>
+                </div>
+                <div class="c-result-item__price">{price}</div>
+            </div>
+        </a>
+        """
+
+    def _page(self, cards):
+        return "<html><body><ul>" + "".join(cards) + "</ul></body></html>"
+
+    def test_basic_parsing(self, mock_response):
+        r = mock_response(self._page([self._card()]))
+        results = HomeResults("interhouse", r)
+        assert len(results.homes) == 1
+        assert results[0].agency == "interhouse"
+        # No house number is ever listed; price is appended for uniqueness.
+        assert results[0].address == "Westerdok [€2750]"
+        assert results[0].city == "Amsterdam"
+        assert results[0].price == 2750
+        assert results[0].sqm == 115
+        assert results[0].url == "https://interhouse.nl/vastgoed/huur/amsterdam/appartement/westerdok/"
+
+    def test_filters_koop_by_url(self, mock_response):
+        # For-sale listings share the markup but live under /vastgoed/koop/.
+        card = self._card(
+            url="https://interhouse.nl/vastgoed/koop/amsterdam/appartement/koopstraat/",
+            price="€ 400.000 k.k.",
+        )
+        r = mock_response(self._page([card]))
+        results = HomeResults("interhouse", r)
+        assert len(results.homes) == 0
+
+    def test_filters_rented(self, mock_response):
+        r = mock_response(self._page([self._card(availability="Verhuurd o.v.")]))
+        results = HomeResults("interhouse", r)
+        assert len(results.homes) == 0
+
+    def test_parses_price_without_notes(self, mock_response):
+        r = mock_response(self._page([self._card(address="Kajuit", price="€ 940 p/mnd")]))
+        results = HomeResults("interhouse", r)
+        assert len(results.homes) == 1
+        assert results[0].price == 940
+        assert results[0].address == "Kajuit [€940]"
+
+    def test_skips_price_without_amount(self, mock_response):
+        r = mock_response(self._page([self._card(price="Prijs op aanvraag")]))
+        results = HomeResults("interhouse", r)
+        assert len(results.homes) == 0
+
+    def test_missing_sqm_is_unset(self, mock_response):
+        r = mock_response(self._page([self._card(area="")]))
+        results = HomeResults("interhouse", r)
+        assert len(results.homes) == 1
+        assert results[0].sqm == -1
+
+    def test_no_cards_returns_empty(self, mock_response):
+        r = mock_response("<html><body>no listings here</body></html>")
+        results = HomeResults("interhouse", r)
         assert len(results.homes) == 0
 
 


### PR DESCRIPTION
## Interhouse

New `parse_interhouse()` parser plus its dispatch branch, and a `hestia-scraper-interhouse` service in both `docker/docker-compose.yml` and `docker/docker-compose-dev.yml`.

Site specifics handled:
- **For-sale listings are mixed into the same feed** with identical markup, so rentals are selected by their `/vastgoed/huur/` URL path.
- **Rented/under-option listings still appear**; their status only shows in the card's availability label, so unavailable listings are filtered on keywords (`verhuurd`, `onder optie`, `withdrawn`, …).
- **No house numbers are ever listed.** Interhouse only publishes the street, so the price is appended to the address (`Westerdok [€2750]`) to keep it usable as a unique identifier — same approach as the At Home and Pararius parsers.
- Price reads as `€ 2.750 p/mnd Exclusief voorzieningen`; only the amount before `p/mnd` is taken and parsed to a plain int.
- Living area renders as `Ca. 115 m²` with the `²` in a `<sup>`, so it is matched as `m\s*[²2]`.

This site has no usable JSON/API endpoint, so it is parsed from rendered HTML.

## Funda

`parse_funda()` raised a bare `KeyError: 'hits'` when Funda's Elasticsearch `_msearch` endpoint returned HTTP 200 with a per-query `error`/`status` object instead of results, which hid the real cause in alerts. It now raises a `ValueError` carrying the status and error payload.

## Tests

`TestParseInterhouse` (7 cases: basic parsing, koop filtering, rented filtering, price with/without notes, missing price, missing sqm, empty page) and `test_error_response_surfaces_cause` for Funda. Full suite: 409 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)